### PR TITLE
Add buggi's extra cheats to `simmaster07:extra-cheats-dll`

### DIFF
--- a/src/yaml/simmaster07/extra-cheats-dll.yaml
+++ b/src/yaml/simmaster07/extra-cheats-dll.yaml
@@ -1,6 +1,6 @@
 group: "simmaster07"
 name: "extra-cheats-dll"
-version: "1.1.2"
+version: "1.1.1-1"
 subfolder: "150-mods"
 assets:
 - assetId: "simmaster07-extra-cheats-dll"
@@ -27,6 +27,6 @@ url: "https://community.simtropolis.com/files/file/31350-simmasters-extra-cheats
 
 ---
 assetId: "buggi-extra-cheats-dll"
-version: "1.1.0"
+version: "1.0"
 lastModified: "2014-05-07T18:32:32Z"
 url: "https://community.simtropolis.com/files/file/21118-simcity-4-extra-cheats-plugin/?do=download"

--- a/src/yaml/simmaster07/extra-cheats-dll.yaml
+++ b/src/yaml/simmaster07/extra-cheats-dll.yaml
@@ -1,9 +1,10 @@
 group: "simmaster07"
 name: "extra-cheats-dll"
-version: "1.1.1"
+version: "1.1.2"
 subfolder: "150-mods"
 assets:
 - assetId: "simmaster07-extra-cheats-dll"
+- assetId: "buggi-extra-cheats-dll"
 
 info:
   summary: "Enables additional cheat codes"
@@ -23,3 +24,9 @@ assetId: "simmaster07-extra-cheats-dll"
 version: "1.1.1"
 lastModified: "2020-06-05T05:32:22Z"
 url: "https://community.simtropolis.com/files/file/31350-simmasters-extra-cheats-dll/?do=download"
+
+---
+assetId: "buggi-extra-cheats-dll"
+version: "1.1.0"
+lastModified: "2014-05-07T18:32:32Z"
+url: "https://community.simtropolis.com/files/file/21118-simcity-4-extra-cheats-plugin/?do=download"


### PR DESCRIPTION
I don't know if it's intentional or not, but `simmaster07:extra-cheats-dll` did not contain [Buggi's extra cheats](https://community.simtropolis.com/files/file/21118-simcity-4-extra-cheats-plugin/) (such as BuildingPlop etc.), only [Simmaster07's](https://community.simtropolis.com/files/file/31350-simmasters-extra-cheats-dll/) extra cheats.

I've changed the metadata to include both dll's with extra cheats. If it was intentional that Buggi's extra cheats were not included, I'll change my PR and add it as a separate package (though I do believe it belongs here).