### PR TITLE
Add NYBT essentials

### DIFF
--- a/src/yaml/nybt/essentials.yaml
+++ b/src/yaml/nybt/essentials.yaml
@@ -1,0 +1,32 @@
+group: nybt
+name: essentials
+version: 1.1.0
+subfolder: 100-props-textures
+
+info:
+  summary: Query windows for NYBT bats
+  description: >
+    This is the NYBT essentials pack for many upcoming releases.
+    It contains query windows - standard NYBT query windows for most common building types and a special 9/11 query.
+    The essentials will be modified and improved when needed.
+  author: "Gwail, NYBT"
+  website: https://community.simtropolis.com/files/file/22916-nybt-essentials/
+
+variants:
+  - variant: { "NYBT.skyline": standard }
+    assets:
+      - assetId: nybt-essentials
+        include: 
+          - "/NYBT_essentials.dat"
+  - variant: { "NYBT.skyline": new }
+    assets:
+      - assetId: nybt-essentials
+        include:
+          - "/NYBT_essentials.dat"
+          - "/zz_NYBT_essentials_new_skyline.dat"
+
+---
+assetId: nybt-essentials
+version: 1.1.0
+lastModified: "2011-06-24T08:00:57Z"
+url: https://community.simtropolis.com/files/file/22916-nybt-essentials/?do=download

--- a/src/yaml/nybt/essentials.yaml
+++ b/src/yaml/nybt/essentials.yaml
@@ -1,32 +1,24 @@
 group: nybt
 name: essentials
-version: 1.1.0
+version: "2"
 subfolder: 100-props-textures
 
 info:
-  summary: Query windows for NYBT bats
+  summary: Query windows for NYBT BATs
   description: >
-    This is the NYBT essentials pack for many upcoming releases.
-    It contains query windows - standard NYBT query windows for most common building types and a special 9/11 query.
-    The essentials will be modified and improved when needed.
-  author: "Gwail, NYBT"
+    This package is a shared dependency of many NYBT BATs
+    and includes standard NYBT query windows for most common building types and a special 9/11 query.
+  author: "Gwail, Aaron Graham, Kelis, NYBT"
   website: https://community.simtropolis.com/files/file/22916-nybt-essentials/
 
-variants:
-  - variant: { "NYBT.skyline": standard }
-    assets:
-      - assetId: nybt-essentials
-        include: 
-          - "/NYBT_essentials.dat"
-  - variant: { "NYBT.skyline": new }
-    assets:
-      - assetId: nybt-essentials
-        include:
-          - "/NYBT_essentials.dat"
-          - "/zz_NYBT_essentials_new_skyline.dat"
+assets:
+  - assetId: nybt-essentials
+    include:
+      - "/NYBT_essentials.dat"
+      - "/zz_NYBT_essentials_new_skyline.dat"
 
 ---
 assetId: nybt-essentials
-version: 1.1.0
+version: "2"
 lastModified: "2011-06-24T08:00:57Z"
 url: https://community.simtropolis.com/files/file/22916-nybt-essentials/?do=download


### PR DESCRIPTION
Makes the [NYBT essentials](https://community.simtropolis.com/files/file/22916-nybt-essentials/) installable via `sc4pac`. This will allow creating metadata for all the bats from the NYBT (most notably those from [Aaron Graham](https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file)) (depending on support for Clickteam installers, see https://github.com/memo33/sc4pac-tools/pull/3)