### PR TITLE
feat: add marrast & stanley seawalls

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -72,6 +72,7 @@ This list will be expanded as more packages are added to the metadata channel.
 - Parks:
   * `pkg=kingofsimcity:community-regional-park-pack-vol1` (11 medium to large parks)
   * `pkg=kingofsimcity:community-regional-park-pack-vol2` (36 parks and sports fields)
+  * `pkg=blunder:stanley-seawalls`
 - Miscellaneous:
   * `pkg=bsc:census-repository` (provides detailed stats about city growth)
   * `pkg=mattb325:galaxy-casino-hotel`

--- a/src/yaml/blunder/stanley-seawalls.yaml
+++ b/src/yaml/blunder/stanley-seawalls.yaml
@@ -6,6 +6,8 @@ info:
   summary: Stanley Seawalls Base Set
   description: >
     A simple set of seawalls inspired by and (loosely) mimicking the seawalls in Stanley Park, Vancouver BC.
+  author: blunder
+  website: "https://community.simtropolis.com/files/file/30868-stanley-seawalls/"
 
 variants:
   - variant: { nightmode: standard }

--- a/src/yaml/blunder/stanley-seawalls.yaml
+++ b/src/yaml/blunder/stanley-seawalls.yaml
@@ -1,0 +1,26 @@
+group: blunder
+name: stanley-seawalls
+version: "1.0"
+subfolder: "660-parks"
+info:
+  summary: Stanley Seawalls Base Set
+  description: >
+    A simple set of seawalls inspired by and (loosely) mimicking the seawalls in Stanley Park, Vancouver BC.
+
+variants:
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: blunder-stanley-seawalls
+        include:
+          - "/Stanley Seawalls Maxisnight/"
+  - variant: { nightmode: dark }
+    assets:
+      - assetId: blunder-stanley-seawalls
+        include:
+          - "/Stanley Seawalls Darknight/"
+
+---
+assetId: blunder-stanley-seawalls
+version: "1.0"
+lastModified: "2015-12-17T04:49:59Z"
+url: https://community.simtropolis.com/files/file/30868-stanley-seawalls/?do=download

--- a/src/yaml/marrast/embankment-set.yaml
+++ b/src/yaml/marrast/embankment-set.yaml
@@ -9,6 +9,8 @@ info:
     Can be found in the seaports menu.
   author: Marrast
   website: https://community.simtropolis.com/files/file/16655-marrasts-embankment-set/
+assets:
+  - assetId: marrast-embankment-set
 
 ---
 assetId: marrast-embankment-set

--- a/src/yaml/marrast/embankment-set.yaml
+++ b/src/yaml/marrast/embankment-set.yaml
@@ -1,0 +1,17 @@
+group: marrast
+name: embankment-set
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Marrast's Embankment Set
+  description: >
+    An embankment set that can be used to create lifelike embankments along your shorelines or river edges in the game.
+    Can be found in the seaports menu.
+  author: Marrast
+  website: https://community.simtropolis.com/files/file/16655-marrasts-embankment-set/
+
+---
+assetId: marrast-embankment-set
+version: "1.0"
+lastModified: "2011-04-18T21:02:58Z"
+url: https://community.simtropolis.com/files/file/16655-marrasts-embankment-set/?do=download


### PR DESCRIPTION
This PR adds the [Marrast embankment set](https://community.simtropolis.com/files/file/16655-marrasts-embankment-set/) and [Blunder's Stanley seawalls](https://community.simtropolis.com/files/file/30868-stanley-seawalls/). Currently I've put them in the `660-parks` subfolder, but I feel that it needs a custom subfolder `seawalls` or something.