### PR TITLE
Add Central European Tree Controller

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -88,6 +88,7 @@ Many additional civic buildings by mattb325 are listed at [Channel](channel/ ':t
 * `pkg=cycledogg:missouri-breaks-terrain` (an SD terrain mod)
 * `pkg=vip:vip-terrain-mod-complete` (an HD terrain mod alternative)
 * `pkg=blunder:pacific-northwest-tree-controller` (seasonal forests; for advanced users)
+* `pkg=11241036:central-european-tree-controller` (an alternative tree controller: seasonal/non-seasonal)
 * `pkg=t-wrecks:maxis-tree-hd-replacement-mod` (HD trees for lots and streets)
 * `pkg=kodlovag:uniform-street-lighting-mod`
 * `pkg=peg:power-tower-pylons` (silvery-gray reskin)

--- a/src/yaml/11241036/central-european-tree-controller.yaml
+++ b/src/yaml/11241036/central-european-tree-controller.yaml
@@ -1,0 +1,76 @@
+group: "11241036"
+name: central-european-tree-controller
+version: "1.03"
+subfolder: 180-flora
+info:
+  summary: Central European Tree Controller
+  warning: >-
+    If using this controller in seasonal mode, seasonal trees must be planted on September 1st.
+    When switching to another tree controller, always remove any and all trees planted with your previous tree controller *before* uninstalling your old tree controller.
+
+    If you want to remove the tree controller, there are few helper files are available on Simtropolis.
+  conflicts: >-
+    If using the seasonal controller, it is only compatible with terrain mods that include the Seasonal Flora Patch.
+    Incompatible with all other tree controllers – only one tree controller may be installed at a time.
+  description: >
+    This plugin provides you with a tree controller, that allows you to plant large forests consisting of trees mostly created by girafe.
+    On lower altitudes, leafy trees are being planted, and the higher you go, eventually mixed forests, conifer forests, shrubby plains and meadows with flowers will appear instead.
+
+    There are a few ways to use this tree controller.
+    You can use it in seasonal mode, in which case the planted flora will change appearance.
+    Alternatively you can choose one of the non-seasonal variants: summer, fall or winter.
+    With this variant, the trees will always look the same, regardless of the in-game time.
+    This is useful if you don't want the trees to change color while playing, but occasionally want to take screenshots in fall or winter mode.
+    In this case, just use sc4pac variant reset CETC.mode and then run sc4pac update again.
+  author: "11241036"
+  website: https://community.simtropolis.com/files/file/31419-central-european-tree-controller/
+
+dependencies:
+  - bsc:mega-props-cp-vol02
+  - girafe:ashes
+  - girafe:beeches
+  - girafe:chestnuts
+  - girafe:maples-v2
+  - girafe:lindens
+  - girafe:oaks
+  - girafe:norway-maples
+  - girafe:common-spruces
+  - girafe:conifers
+  - girafe:subalpine-firs
+  - girafe:larches
+  - girafe:daisy
+  - girafe:sparaxis
+  - girafe:narcissus
+  - girafe:bushes
+
+variants:
+  - variant: { CETC.mode: seasonal }
+    assets:
+      - assetId: "11241036-central-european-tree-controller"
+        include:
+          - Central European Tree Controller_Seasonal v1_03.dat
+          - Maxis TC Disabler.dat
+  - variant: { CETC.mode: summer }
+    assets:
+      - assetId: "11241036-central-european-tree-controller"
+        include:
+          - Central European Tree Controller_Evergreen SUMMER v1_03.dat
+          - Maxis TC Disabler.dat
+  - variant: { CETC.mode: fall }
+    assets:
+      - assetId: "11241036-central-european-tree-controller"
+        include:
+          - Central European Tree Controller_Evergreen FALL v1_03.dat
+          - Maxis TC Disabler.dat
+  - variant: { CETC.mode: winter }
+    assets:
+      - assetId: "11241036-central-european-tree-controller"
+        include:
+          - Central European Tree Controller_Evergreen WINTER v1_03.dat
+          - Maxis TC Disabler.dat
+
+---
+assetId: "11241036-central-european-tree-controller"
+version: "1.03"
+lastModified: "2024-03-09T21:52:48Z"
+url: https://community.simtropolis.com/files/file/31419-central-european-tree-controller/?do=download

--- a/src/yaml/11241036/central-european-tree-controller.yaml
+++ b/src/yaml/11241036/central-european-tree-controller.yaml
@@ -8,20 +8,20 @@ info:
     If using this controller in seasonal mode, seasonal trees must be planted on September 1st.
     When switching to another tree controller, always remove any and all trees planted with your previous tree controller *before* uninstalling your old tree controller.
 
-    If you want to remove the tree controller, there are few helper files are available on Simtropolis.
+    If you want to remove this tree controller, there are some helper files available on Simtropolis.
   conflicts: >-
-    If using the seasonal controller, it is only compatible with terrain mods that include the Seasonal Flora Patch.
+    The seasonal controller variant is only compatible with terrain mods that include the Seasonal Flora Patch.
     Incompatible with all other tree controllers – only one tree controller may be installed at a time.
   description: >
     This plugin provides you with a tree controller, that allows you to plant large forests consisting of trees mostly created by girafe.
     On lower altitudes, leafy trees are being planted, and the higher you go, eventually mixed forests, conifer forests, shrubby plains and meadows with flowers will appear instead.
 
     There are a few ways to use this tree controller.
-    You can use it in seasonal mode, in which case the planted flora will change appearance.
+    You can use it in seasonal mode, in which case the planted flora will change appearance throughout the year.
     Alternatively you can choose one of the non-seasonal variants: summer, fall or winter.
-    With this variant, the trees will always look the same, regardless of the in-game time.
+    With such a variant, the trees will always look the same, regardless of the in-game time.
     This is useful if you don't want the trees to change color while playing, but occasionally want to take screenshots in fall or winter mode.
-    In this case, just use sc4pac variant reset CETC.mode and then run sc4pac update again.
+    In this case, use `sc4pac variant reset CETC.mode` and then run `sc4pac update` again.
   author: "11241036"
   website: https://community.simtropolis.com/files/file/31419-central-european-tree-controller/
 
@@ -68,6 +68,13 @@ variants:
         include:
           - Central European Tree Controller_Evergreen WINTER v1_03.dat
           - Maxis TC Disabler.dat
+
+variantDescriptions:
+  CETC.mode:
+    seasonal: trees changing appearance throughout the year
+    summer: evergreen trees
+    fall: fall foliage for the entire year
+    winter: leafless trees for the entire year
 
 ---
 assetId: "11241036-central-european-tree-controller"


### PR DESCRIPTION
This PR adds the [Central European Tree Controller](https://community.simtropolis.com/files/file/31419-central-european-tree-controller/). In my opinion it's one of the best out there due to the unique approach that you can easily switch between the seasonal, or non-seasonal variants, where the non-seasonal variants still allow you to choose for summer, fall or winter.

In combination with `sc4pac variant reset`, this is extremely powerful and makes it a breeze to quickly change the appearance of your flora, without the need for the full seasonal controller (which can have its own issues as well).

Note that the download on Simtropolis contains a few additional files that help with uninstalling this controller:

 > - CETC Disabler_[Name appendix].dat: These files disable the CETC, however, you can keep all trees that have previously been planted by the CETC. Remember: As long as you have trees in your region planted by the CETC, you either need the CETC itself, one of these four files (depending on whether you have installed the evergreen or the seasonal CETC), or the subsequently mentioned file.
> - CETC Uninstallation Helper.dat: If you want to remove all trees that you have planted with the CETC, you may want to install this file: It disables the CETC as well, and furthermore, it replaces all trees planted by it with brown boxes (while keeping mayor-mode planted trees the way they are). This way, you can find out which trees in particular have been planted with the CETC and remove them easily. This file works independently from whether you have installed the evergreen or the seasonal CETC.

Obviously I did not include these files. I just mentioned it in the warning that these files exist if you want to uninstall again. Alternatively we could also release these helpers as a separate package. Something like `11241036:central-european-tree-controller-uninstall-helpers` What's your opinion, @memo33 ?