### PR TITLE
bump version: shk-hd-rock-mods

### DIFF
--- a/src/yaml/shk/hd-rock-mods.yaml
+++ b/src/yaml/shk/hd-rock-mods.yaml
@@ -1,6 +1,6 @@
 assetId: "shk-hd-rock-mods"
-version: "1.0"
-lastModified: "2017-02-02T05:55:19Z"
+version: "1.0.1"
+lastModified: "2024-03-29T03:20:17Z"
 url: "https://community.simtropolis.com/files/file/27655-shk-hd-rock-mods/?do=download"
 
 ---


### PR DESCRIPTION
Updated SHK HD Rock Mods at Simtropolis to fix the DBPF major.minor version for datpacking with jdatpacker.