### PR TITLE
Add complete Aaron Graham collection

### DIFF
--- a/src/yaml/aaron-graham/1225-morris-avenue.yaml
+++ b/src/yaml/aaron-graham/1225-morris-avenue.yaml
@@ -3,7 +3,7 @@ name: 1225-morris-avenue
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: 1225 Morris Avenue
+  summary: 1225 Morris Avenue (W2W)
   description: >
     1225 Morris Avenue is a 1937 six story apartment located in The Bronx, New York City.
     The building grows as R$ and R$$ in four color variations on the New York tile set.

--- a/src/yaml/aaron-graham/1225-morris-avenue.yaml
+++ b/src/yaml/aaron-graham/1225-morris-avenue.yaml
@@ -6,7 +6,7 @@ info:
   summary: 1225 Morris Avenue
   description: >
     1225 Morris Avenue is a 1937 six story apartment located in The Bronx, New York City.
-    The building grows as R$ and R$$ on the New York tile set.
+    The building grows as R$ and R$$ in four color variations on the New York tile set.
     It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/28949-nybt-1225-morris-avenue/

--- a/src/yaml/aaron-graham/1225-morris-avenue.yaml
+++ b/src/yaml/aaron-graham/1225-morris-avenue.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: 1225-morris-avenue
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: 1225 Morris Avenue
+  description: >
+    1225 Morris Avenue is a 1937 six story apartment located in The Bronx, New York City.
+    The building grows as R$ and R$$ on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/28949-nybt-1225-morris-avenue/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-1225-morris-avenue-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-1225-morris-avenue-maxisnite
+
+---
+assetId: aaron-graham-1225-morris-avenue-darknite
+version: "1.0"
+lastModified: "2013-09-01T03:24:38Z"
+url: https://community.simtropolis.com/files/file/28949-nybt-1225-morris-avenue/?do=download&r=120960
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-1225-morris-avenue-maxisnite
+version: "1.0"
+lastModified: "2013-09-01T03:24:38Z"
+url: https://community.simtropolis.com/files/file/28949-nybt-1225-morris-avenue/?do=download&r=120959
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/201-e-19-street.yaml
+++ b/src/yaml/aaron-graham/201-e-19-street.yaml
@@ -1,0 +1,39 @@
+group: aaron-graham
+name: 201-e-19-street
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: 201 E. 19 Street
+  description: >
+    201 E. 19 Street is a 1960 sixteen story brick apartment located in Manhattan, New York City.
+    The building grows as R$$, R$$$, CS$$ and CS$$$ in four color variations on the New York tile set.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/28649-nybt-201-e-19-street/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-201-e-19-street-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-201-e-19-street-maxisnite
+
+---
+assetId: aaron-graham-201-e-19-street-darknite
+version: "1.0"
+lastModified: "2013-04-19T09:31:44Z"
+url: https://community.simtropolis.com/files/file/28649-nybt-201-e-19-street/?do=download&r=114199
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-201-e-19-street-maxisnite
+version: "1.0"
+lastModified: "2013-04-19T09:31:44Z"
+url: https://community.simtropolis.com/files/file/28649-nybt-201-e-19-street/?do=download&r=114198
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/201-e-19-street.yaml
+++ b/src/yaml/aaron-graham/201-e-19-street.yaml
@@ -3,6 +3,7 @@ name: 201-e-19-street
 version: "1.0"
 subfolder: 200-residential
 dependencies:
+  - "nybt:essentials"
   - "girafe:maples-v2"
 info:
   summary: 201 E. 19 Street
@@ -12,7 +13,6 @@ info:
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/28649-nybt-201-e-19-street/
 
-dependencies: ["nybt:essentials"]
 variants:
   - variant: { nightmode: dark }
     dependencies: ["simfox:day-and-nite-mod"]

--- a/src/yaml/aaron-graham/201-e-19-street.yaml
+++ b/src/yaml/aaron-graham/201-e-19-street.yaml
@@ -2,6 +2,8 @@ group: aaron-graham
 name: 201-e-19-street
 version: "1.0"
 subfolder: 200-residential
+dependencies:
+  - "girafe:maples-v2"
 info:
   summary: 201 E. 19 Street
   description: >

--- a/src/yaml/aaron-graham/25-e-193-street.yaml
+++ b/src/yaml/aaron-graham/25-e-193-street.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: 25-e-193-street
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: 25 E. 193 Street
+  description: >
+    25 E. 193 Street is a 1921 five story apartment located in The Bronx, New York City.
+    The building grows as R$ and R$$ on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/29835-nybt-25-e-193-street/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-25-e-193-street-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-25-e-193-street-maxisnite
+
+---
+assetId: aaron-graham-25-e-193-street-darknite
+version: "1.0"
+lastModified: "2014-08-20T03:40:35Z"
+url: https://community.simtropolis.com/files/file/29835-nybt-25-e-193-street/?do=download&r=140597
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-25-e-193-street-maxisnite
+version: "1.0"
+lastModified: "2014-08-20T03:40:35Z"
+url: https://community.simtropolis.com/files/file/29835-nybt-25-e-193-street/?do=download&r=140596
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/25-e-193-street.yaml
+++ b/src/yaml/aaron-graham/25-e-193-street.yaml
@@ -6,7 +6,7 @@ info:
   summary: 25 E. 193 Street
   description: >
     25 E. 193 Street is a 1921 five story apartment located in The Bronx, New York City.
-    The building grows as R$ and R$$ on the New York tile set.
+    The building grows as R$ and R$$ in four color variations on the New York tile set.
     It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/29835-nybt-25-e-193-street/

--- a/src/yaml/aaron-graham/25-e-193-street.yaml
+++ b/src/yaml/aaron-graham/25-e-193-street.yaml
@@ -3,7 +3,7 @@ name: 25-e-193-street
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: 25 E. 193 Street
+  summary: 25 E. 193 Street (W2W)
   description: >
     25 E. 193 Street is a 1921 five story apartment located in The Bronx, New York City.
     The building grows as R$ and R$$ in four color variations on the New York tile set.

--- a/src/yaml/aaron-graham/2639-and-2641-jerome-avenue.yaml
+++ b/src/yaml/aaron-graham/2639-and-2641-jerome-avenue.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: 2639-and-2641-jerome-avenue
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: 2639 And 2641 Jerome Avenue
+  description: >
+    2369 And 2641 Jerome avenue is a 1912 five story walk up apartment located in The Bronx, New York City.
+    The building grows as R$ and R$$ in four color variations on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/30167-nybt-2639-and-2641-jerome-avenue/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-2639-and-2641-jerome-avenue-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-2639-and-2641-jerome-avenue-maxisnite
+
+---
+assetId: aaron-graham-2639-and-2641-jerome-avenue-darknite
+version: "1.0"
+lastModified: "2015-03-01T03:57:22Z"
+url: https://community.simtropolis.com/files/file/30167-nybt-2639-and-2641-jerome-avenue/?do=download&r=148489
+archiveType:
+  format: Clickteam
+  version: "35"
+
+---
+assetId: aaron-graham-2639-and-2641-jerome-avenue-maxisnite
+version: "1.0"
+lastModified: "2015-03-01T03:57:22Z"
+url: https://community.simtropolis.com/files/file/30167-nybt-2639-and-2641-jerome-avenue/?do=download&r=148488
+archiveType:
+  format: Clickteam
+  version: "35"

--- a/src/yaml/aaron-graham/2639-and-2641-jerome-avenue.yaml
+++ b/src/yaml/aaron-graham/2639-and-2641-jerome-avenue.yaml
@@ -6,7 +6,7 @@ info:
   summary: 2639 And 2641 Jerome Avenue
   description: >
     2369 And 2641 Jerome avenue is a 1912 five story walk up apartment located in The Bronx, New York City.
-    The building grows as R$ and R$$ in four color variations on the New York tile set.
+    The building grows as R$, R$$, C$ and C$$ in four color variations on the New York tile set.
     It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/30167-nybt-2639-and-2641-jerome-avenue/

--- a/src/yaml/aaron-graham/2639-and-2641-jerome-avenue.yaml
+++ b/src/yaml/aaron-graham/2639-and-2641-jerome-avenue.yaml
@@ -3,7 +3,7 @@ name: 2639-and-2641-jerome-avenue
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: 2639 And 2641 Jerome Avenue
+  summary: 2639 And 2641 Jerome Avenue (W2W)
   description: >
     2369 And 2641 Jerome avenue is a 1912 five story walk up apartment located in The Bronx, New York City.
     The building grows as R$, R$$, C$ and C$$ in four color variations on the New York tile set.

--- a/src/yaml/aaron-graham/30-e-81-street.yaml
+++ b/src/yaml/aaron-graham/30-e-81-street.yaml
@@ -3,7 +3,7 @@ name: 30-e-81-street
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: 30 E. 81 Street
+  summary: 30 E. 81 Street (W2W)
   description: >
     30 E. 81 Street is a 1955 thirteen story apartment located in Manhattan, New York City.
     The building grows as R$$, R$$$, CS$$ and CS$$$ on the New York tile set.

--- a/src/yaml/aaron-graham/30-e-81-street.yaml
+++ b/src/yaml/aaron-graham/30-e-81-street.yaml
@@ -25,7 +25,7 @@ variants:
 assetId: aaron-graham-30-e-81-street-darknite
 version: "1.0"
 lastModified: "2013-03-15T04:00:28Z"
-url: https://community.simtropolis.com/files/file/28572-nybt-30-e-81-street/?do=download&r=113248&corner=true
+url: https://community.simtropolis.com/files/file/28572-nybt-30-e-81-street/?do=download&r=113248
 archiveType:
   format: Clickteam
   version: "40"
@@ -34,7 +34,7 @@ archiveType:
 assetId: aaron-graham-30-e-81-street-maxisnite
 version: "1.0"
 lastModified: "2013-03-15T04:00:28Z"
-url: https://community.simtropolis.com/files/file/28572-nybt-30-e-81-street/?do=download&r=113247&corner=true
+url: https://community.simtropolis.com/files/file/28572-nybt-30-e-81-street/?do=download&r=113247
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/30-e-81-street.yaml
+++ b/src/yaml/aaron-graham/30-e-81-street.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: 30-e-81-street
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: 30 E. 81 Street
+  description: >
+    30 E. 81 Street is a 1955 thirteen story apartment located in Manhattan, New York City.
+    The building grows as R$$, R$$$, CS$$ and CS$$$ on the New York tile set.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/28572-nybt-30-e-81-street/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-30-e-81-street-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-30-e-81-street-maxisnite
+
+---
+assetId: aaron-graham-30-e-81-street-darknite
+version: "1.0"
+lastModified: "2013-03-15T04:00:28Z"
+url: https://community.simtropolis.com/files/file/28572-nybt-30-e-81-street/?do=download&r=113248&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-30-e-81-street-maxisnite
+version: "1.0"
+lastModified: "2013-03-15T04:00:28Z"
+url: https://community.simtropolis.com/files/file/28572-nybt-30-e-81-street/?do=download&r=113247&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/32-48-30th-street.yaml
+++ b/src/yaml/aaron-graham/32-48-30th-street.yaml
@@ -3,7 +3,7 @@ name: 32-48-30th-street
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: 32
+  summary: 32-48 30th Street
   description: >
     32-48 30th Street is a 1928 apartment located in Queens, New York City.
     The building grows as R$$ and R$$$ in eight color variations the New York tile set.

--- a/src/yaml/aaron-graham/32-48-30th-street.yaml
+++ b/src/yaml/aaron-graham/32-48-30th-street.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: 32-48-30th-street
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: 32
+  description: >
+    32-48 30th Street is a 1928 apartment located in Queens, New York City.
+    The building grows as R$$ and R$$$ in eight color variations the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/28818-nybt-32-48-30th-street/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-32-48-30th-street-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-32-48-30th-street-maxisnite
+
+---
+assetId: aaron-graham-32-48-30th-street-darknite
+version: "1.0"
+lastModified: "2013-07-01T00:17:53Z"
+url: https://community.simtropolis.com/files/file/28818-nybt-32-48-30th-street/?do=download&r=116815
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-32-48-30th-street-maxisnite
+version: "1.0"
+lastModified: "2013-07-01T00:17:53Z"
+url: https://community.simtropolis.com/files/file/28818-nybt-32-48-30th-street/?do=download&r=116814
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/32-48-30th-street.yaml
+++ b/src/yaml/aaron-graham/32-48-30th-street.yaml
@@ -3,7 +3,7 @@ name: 32-48-30th-street
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: 32-48 30th Street
+  summary: 32-48 30th Street (W2W)
   description: >
     32-48 30th Street is a 1928 apartment located in Queens, New York City.
     The building grows as R$$ and R$$$ in eight color variations the New York tile set.

--- a/src/yaml/aaron-graham/41-park-avenue.yaml
+++ b/src/yaml/aaron-graham/41-park-avenue.yaml
@@ -3,6 +3,7 @@ name: 41-park-avenue
 version: "1.0"
 subfolder: 200-residential
 dependencies:
+  - "nybt:essentials"
   - "bsc:mega-props-cp-vol01"
 info:
   summary: 41 Park Avenue
@@ -13,7 +14,6 @@ info:
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/27913-nybt-41-park-avenue/
 
-dependencies: ["nybt:essentials"]
 variants:
   - variant: { nightmode: dark }
     dependencies: ["simfox:day-and-nite-mod"]

--- a/src/yaml/aaron-graham/41-park-avenue.yaml
+++ b/src/yaml/aaron-graham/41-park-avenue.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: 41-park-avenue
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: 41 Park Avenue
+  description: >
+    41 Park Avenue is a 1950 apartment located in Manhattan, New York City.
+    The building grows as R$ and R$$ on the New York tile set.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/27913-nybt-41-park-avenue/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-41-park-avenue-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-41-park-avenue-maxisnite
+
+---
+assetId: aaron-graham-41-park-avenue-darknite
+version: "1.0"
+lastModified: "2012-08-10T04:02:56Z"
+url: https://community.simtropolis.com/files/file/27913-nybt-41-park-avenue/?do=download&r=109903&year=1950&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-41-park-avenue-maxisnite
+version: "1.0"
+lastModified: "2012-08-10T04:02:56Z"
+url: https://community.simtropolis.com/files/file/27913-nybt-41-park-avenue/?do=download&r=109902&year=1950&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/41-park-avenue.yaml
+++ b/src/yaml/aaron-graham/41-park-avenue.yaml
@@ -6,7 +6,7 @@ dependencies:
   - "nybt:essentials"
   - "bsc:mega-props-cp-vol01"
 info:
-  summary: 41 Park Avenue
+  summary: 41 Park Avenue (W2W)
   description: >
     41 Park Avenue is a 1950 apartment located in Manhattan, New York City.
     The building grows as R$ and R$$ on the New York tile set.

--- a/src/yaml/aaron-graham/41-park-avenue.yaml
+++ b/src/yaml/aaron-graham/41-park-avenue.yaml
@@ -27,7 +27,7 @@ variants:
 assetId: aaron-graham-41-park-avenue-darknite
 version: "1.0"
 lastModified: "2012-08-10T04:02:56Z"
-url: https://community.simtropolis.com/files/file/27913-nybt-41-park-avenue/?do=download&r=109903&year=1950&corner=true
+url: https://community.simtropolis.com/files/file/27913-nybt-41-park-avenue/?do=download&r=109903
 archiveType:
   format: Clickteam
   version: "40"
@@ -36,7 +36,5 @@ archiveType:
 assetId: aaron-graham-41-park-avenue-maxisnite
 version: "1.0"
 lastModified: "2012-08-10T04:02:56Z"
-url: https://community.simtropolis.com/files/file/27913-nybt-41-park-avenue/?do=download&r=109902&year=1950&corner=true
-archiveType:
-  format: Clickteam
-  version: "40"
+# cicdec fails to unpack the installer for this one, so we download the zip from GitHub instead.
+url: https://github.com/memo33/sc4pac-tools/releases/download/0.1.0/NYBT.41.Park.Avenue.Maxis.Nite.2012.zip

--- a/src/yaml/aaron-graham/41-park-avenue.yaml
+++ b/src/yaml/aaron-graham/41-park-avenue.yaml
@@ -2,6 +2,8 @@ group: aaron-graham
 name: 41-park-avenue
 version: "1.0"
 subfolder: 200-residential
+dependencies:
+  - "bsc:mega-props-cp-vol01"
 info:
   summary: 41 Park Avenue
   description: >

--- a/src/yaml/aaron-graham/605-park-avenue.yaml
+++ b/src/yaml/aaron-graham/605-park-avenue.yaml
@@ -3,7 +3,7 @@ name: 605-park-avenue
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: 605 Park Avenue
+  summary: 605 Park Avenue (W2W)
   description: >
     605 Park Avenue is a 1952 apartment located in Manhattan, New York City.
     The building grows as R$$ and R$$$ in four variations (two models and three colors) on the New York tile set.

--- a/src/yaml/aaron-graham/605-park-avenue.yaml
+++ b/src/yaml/aaron-graham/605-park-avenue.yaml
@@ -25,7 +25,7 @@ variants:
 assetId: aaron-graham-605-park-avenue-darknite
 version: "1.0"
 lastModified: "2012-10-05T04:00:53Z"
-url: https://community.simtropolis.com/files/file/28083-nybt-605-park-avenue/?do=download&r=108025&year=1952
+url: https://community.simtropolis.com/files/file/28083-nybt-605-park-avenue/?do=download&r=108025
 archiveType:
   format: Clickteam
   version: "40"
@@ -34,7 +34,7 @@ archiveType:
 assetId: aaron-graham-605-park-avenue-maxisnite
 version: "1.0"
 lastModified: "2012-10-05T04:00:53Z"
-url: https://community.simtropolis.com/files/file/28083-nybt-605-park-avenue/?do=download&r=108024&year=1952
+url: https://community.simtropolis.com/files/file/28083-nybt-605-park-avenue/?do=download&r=108024
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/605-park-avenue.yaml
+++ b/src/yaml/aaron-graham/605-park-avenue.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: 605-park-avenue
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: 605 Park Avenue
+  description: >
+    605 Park Avenue is a 1952 apartment located in Manhattan, New York City.
+    The building grows as R$$ and R$$$ in four variations (two models and three colors) on the New York tile set.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/28083-nybt-605-park-avenue/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-605-park-avenue-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-605-park-avenue-maxisnite
+
+---
+assetId: aaron-graham-605-park-avenue-darknite
+version: "1.0"
+lastModified: "2012-10-05T04:00:53Z"
+url: https://community.simtropolis.com/files/file/28083-nybt-605-park-avenue/?do=download&r=108025&year=1952
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-605-park-avenue-maxisnite
+version: "1.0"
+lastModified: "2012-10-05T04:00:53Z"
+url: https://community.simtropolis.com/files/file/28083-nybt-605-park-avenue/?do=download&r=108024&year=1952
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/655-e-228-street.yaml
+++ b/src/yaml/aaron-graham/655-e-228-street.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: 655-e-228-street
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: 655 E. 228 Street
+  description: >
+    655 E. 228 Street is a 1939 six story apartment located in The Bronx, New York City.
+    The building grows as R$ and R$$ on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/29076-nybt-655-e-228-street/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-655-e-228-street-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-655-e-228-street-maxisnite
+
+---
+assetId: aaron-graham-655-e-228-street-darknite
+version: "1.0"
+lastModified: "2013-12-01T03:49:41Z"
+url: https://community.simtropolis.com/files/file/29076-nybt-655-e-228-street/?do=download&r=121140
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-655-e-228-street-maxisnite
+version: "1.0"
+lastModified: "2013-12-01T03:49:41Z"
+url: https://community.simtropolis.com/files/file/29076-nybt-655-e-228-street/?do=download&r=121139
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/655-e-228-street.yaml
+++ b/src/yaml/aaron-graham/655-e-228-street.yaml
@@ -3,7 +3,7 @@ name: 655-e-228-street
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: 655 E. 228 Street
+  summary: 655 E. 228 Street (W2W)
   description: >
     655 E. 228 Street is a 1939 six story apartment located in The Bronx, New York City.
     The building grows as R$ and R$$ in four color variations on the New York tile set.

--- a/src/yaml/aaron-graham/655-e-228-street.yaml
+++ b/src/yaml/aaron-graham/655-e-228-street.yaml
@@ -6,7 +6,7 @@ info:
   summary: 655 E. 228 Street
   description: >
     655 E. 228 Street is a 1939 six story apartment located in The Bronx, New York City.
-    The building grows as R$ and R$$ on the New York tile set.
+    The building grows as R$ and R$$ in four color variations on the New York tile set.
     It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/29076-nybt-655-e-228-street/

--- a/src/yaml/aaron-graham/785-park-avenue.yaml
+++ b/src/yaml/aaron-graham/785-park-avenue.yaml
@@ -3,7 +3,7 @@ name: 785-park-avenue
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: 785 Park Avenue
+  summary: 785 Park Avenue (W2W)
   description: >
     785 Park Avenue is a sixteen story brick apartment located in Manhattan, New York City.
     The building grows as R$$, R$$$, CS$$ and CS$$$ in four color variations on the New York tile set.

--- a/src/yaml/aaron-graham/785-park-avenue.yaml
+++ b/src/yaml/aaron-graham/785-park-avenue.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: 785-park-avenue
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: 785 Park Avenue
+  description: >
+    785 Park Avenue is a sixteen story brick apartment located in Manhattan, New York City.
+    The building grows as R$$, R$$$, CS$$ and CS$$$ in four color variations on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/28741-nybt-785-park-avenue/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-785-park-avenue-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-785-park-avenue-maxisnite
+
+---
+assetId: aaron-graham-785-park-avenue-darknite
+version: "1.0"
+lastModified: "2013-05-24T04:27:34Z"
+url: https://community.simtropolis.com/files/file/28741-nybt-785-park-avenue/?do=download&r=115636
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-785-park-avenue-maxisnite
+version: "1.0"
+lastModified: "2013-05-24T04:27:34Z"
+url: https://community.simtropolis.com/files/file/28741-nybt-785-park-avenue/?do=download&r=115635
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/915-west-end-avenue.yaml
+++ b/src/yaml/aaron-graham/915-west-end-avenue.yaml
@@ -3,7 +3,7 @@ name: 915-west-end-avenue
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: 915 West End Avenue
+  summary: 915 West End Avenue (W2W)
   description: >
     915 West End Avenue is a 1922 apartment building located in Manhattan, New York City.
     The building grows as R$$ and R$$$ on the New York and Chicago tile sets.

--- a/src/yaml/aaron-graham/915-west-end-avenue.yaml
+++ b/src/yaml/aaron-graham/915-west-end-avenue.yaml
@@ -6,7 +6,7 @@ info:
   summary: 915 West End Avenue
   description: >
     915 West End Avenue is a 1922 apartment building located in Manhattan, New York City.
-    The building grows as R$$ and R$$$ on the New York tile set.
+    The building grows as R$$ and R$$$ on the New York and Chicago tile sets.
     It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/28340-nybt-915-west-end-avenue/

--- a/src/yaml/aaron-graham/915-west-end-avenue.yaml
+++ b/src/yaml/aaron-graham/915-west-end-avenue.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: 915-west-end-avenue
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: 915 West End Avenue
+  description: >
+    915 West End Avenue is a 1922 apartment building located in Manhattan, New York City.
+    The building grows as R$$ and R$$$ on the New York tile set.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/28340-nybt-915-west-end-avenue/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-915-west-end-avenue-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-915-west-end-avenue-maxisnite
+
+---
+assetId: aaron-graham-915-west-end-avenue-darknite
+version: "1.0"
+lastModified: "2013-01-01T05:00:13Z"
+url: https://community.simtropolis.com/files/file/28340-nybt-915-west-end-avenue/?do=download&r=115416&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-915-west-end-avenue-maxisnite
+version: "1.0"
+lastModified: "2013-01-01T05:00:13Z"
+url: https://community.simtropolis.com/files/file/28340-nybt-915-west-end-avenue/?do=download&r=115415&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/915-west-end-avenue.yaml
+++ b/src/yaml/aaron-graham/915-west-end-avenue.yaml
@@ -25,7 +25,7 @@ variants:
 assetId: aaron-graham-915-west-end-avenue-darknite
 version: "1.0"
 lastModified: "2013-01-01T05:00:13Z"
-url: https://community.simtropolis.com/files/file/28340-nybt-915-west-end-avenue/?do=download&r=115416&corner=true
+url: https://community.simtropolis.com/files/file/28340-nybt-915-west-end-avenue/?do=download&r=115416
 archiveType:
   format: Clickteam
   version: "40"
@@ -34,7 +34,7 @@ archiveType:
 assetId: aaron-graham-915-west-end-avenue-maxisnite
 version: "1.0"
 lastModified: "2013-01-01T05:00:13Z"
-url: https://community.simtropolis.com/files/file/28340-nybt-915-west-end-avenue/?do=download&r=115415&corner=true
+url: https://community.simtropolis.com/files/file/28340-nybt-915-west-end-avenue/?do=download&r=115415
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/aronic-place.yaml
+++ b/src/yaml/aaron-graham/aronic-place.yaml
@@ -3,7 +3,7 @@ name: aronic-place
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Aronic Place
+  summary: Aronic Place (W2W)
   description: >
     Aronic Place is a fictitious six story apartment based on 9511 Shore Rd, Brooklyn, New York City.
     The building grows as R$, R$$ and R$$$ on the New York tile set.

--- a/src/yaml/aaron-graham/aronic-place.yaml
+++ b/src/yaml/aaron-graham/aronic-place.yaml
@@ -1,0 +1,41 @@
+group: aaron-graham
+name: aronic-place
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Aronic Place
+  description: >
+    Aronic Place is a fictitious six story apartment based on 9511 Shore Rd, Brooklyn, New York City.
+    The building grows as R$, R$$ and R$$$ on the New York tile set.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/29147-aronic-place/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-aronic-place-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-aronic-place-maxisnite
+
+---
+assetId: aaron-graham-aronic-place-darknite
+version: "1.0"
+lastModified: "2013-12-28T03:53:53Z"
+url: https://community.simtropolis.com/files/file/29147-aronic-place/?do=download&r=122091
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-aronic-place-maxisnite
+version: "1.0"
+lastModified: "2013-12-28T03:53:53Z"
+url: https://community.simtropolis.com/files/file/29147-aronic-place/?do=download&r=122090
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/bainbridge-row.yaml
+++ b/src/yaml/aaron-graham/bainbridge-row.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: bainbridge-row
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Bainbridge Row
+  description: >
+    Bainbridge Row is an apartment located in The Bronx, New York City.
+    The building grows as R$ and R$$ on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/26436-nybt-bainbridge-row/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-bainbridge-row-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-bainbridge-row-maxisnite
+
+---
+assetId: aaron-graham-bainbridge-row-darknite
+version: "1.0"
+lastModified: "2011-07-25T19:30:29Z"
+url: https://community.simtropolis.com/files/file/26436-nybt-bainbridge-row/?do=download&r=95734&where=The+Bronx
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-bainbridge-row-maxisnite
+version: "1.0"
+lastModified: "2011-07-25T19:30:29Z"
+url: https://community.simtropolis.com/files/file/26436-nybt-bainbridge-row/?do=download&r=95733&where=The+Bronx
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/bainbridge-row.yaml
+++ b/src/yaml/aaron-graham/bainbridge-row.yaml
@@ -3,7 +3,7 @@ name: bainbridge-row
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Bainbridge Row
+  summary: Bainbridge Row (W2W)
   description: >
     Bainbridge Row is an apartment located in The Bronx, New York City.
     The building grows as R$ and R$$ on the New York tile set.

--- a/src/yaml/aaron-graham/bainbridge-row.yaml
+++ b/src/yaml/aaron-graham/bainbridge-row.yaml
@@ -25,7 +25,7 @@ variants:
 assetId: aaron-graham-bainbridge-row-darknite
 version: "1.0"
 lastModified: "2011-07-25T19:30:29Z"
-url: https://community.simtropolis.com/files/file/26436-nybt-bainbridge-row/?do=download&r=95734&where=The+Bronx
+url: https://community.simtropolis.com/files/file/26436-nybt-bainbridge-row/?do=download&r=95734
 archiveType:
   format: Clickteam
   version: "40"
@@ -34,7 +34,7 @@ archiveType:
 assetId: aaron-graham-bainbridge-row-maxisnite
 version: "1.0"
 lastModified: "2011-07-25T19:30:29Z"
-url: https://community.simtropolis.com/files/file/26436-nybt-bainbridge-row/?do=download&r=95733&where=The+Bronx
+url: https://community.simtropolis.com/files/file/26436-nybt-bainbridge-row/?do=download&r=95733
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/barton-paul.yaml
+++ b/src/yaml/aaron-graham/barton-paul.yaml
@@ -3,7 +3,7 @@ name: barton-paul
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Barton Paul
+  summary: Barton Paul (W2W)
   description: >
     Barton Paul is a 1955 five story apartment located in The Bronx, New York City.
     The building grows as R$ and R$$ in four color variations on the New York tile set.

--- a/src/yaml/aaron-graham/barton-paul.yaml
+++ b/src/yaml/aaron-graham/barton-paul.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: barton-paul
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Barton Paul
+  description: >
+    Barton Paul is a 1955 five story apartment in New York City.
+    The building grows as R$ and R$$ in four color variations on the New York tile set.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/30118-nybt-barton-paul/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-barton-paul-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-barton-paul-maxisnite
+
+---
+assetId: aaron-graham-barton-paul-darknite
+version: "1.0"
+lastModified: "2015-01-30T05:00:29Z"
+url: https://community.simtropolis.com/files/file/30118-nybt-barton-paul/?do=download&r=147472
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-barton-paul-maxisnite
+version: "1.0"
+lastModified: "2015-01-30T05:00:29Z"
+url: https://community.simtropolis.com/files/file/30118-nybt-barton-paul/?do=download&r=147471
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/barton-paul.yaml
+++ b/src/yaml/aaron-graham/barton-paul.yaml
@@ -5,7 +5,7 @@ subfolder: 200-residential
 info:
   summary: Barton Paul
   description: >
-    Barton Paul is a 1955 five story apartment in New York City.
+    Barton Paul is a 1955 five story apartment located in The Bronx, New York City.
     The building grows as R$ and R$$ in four color variations on the New York tile set.
     It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
   author: Aaron Graham

--- a/src/yaml/aaron-graham/beck-arms.yaml
+++ b/src/yaml/aaron-graham/beck-arms.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: beck-arms
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Beck Arms
+  description: >
+    Beck Arms is an apartment located in The Bronx, New York City.
+    The building grows as R$ and R$$ on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/26470-nybt-beck-arms/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-beck-arms-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-beck-arms-maxisnite
+
+---
+assetId: aaron-graham-beck-arms-darknite
+version: "1.0"
+lastModified: "2011-07-08T04:04:06Z"
+url: https://community.simtropolis.com/files/file/26470-nybt-beck-arms/?do=download&r=95455
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-beck-arms-maxisnite
+version: "1.0"
+lastModified: "2011-07-08T04:04:06Z"
+url: https://community.simtropolis.com/files/file/26470-nybt-beck-arms/?do=download&r=95454
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/beck-arms.yaml
+++ b/src/yaml/aaron-graham/beck-arms.yaml
@@ -3,7 +3,7 @@ name: beck-arms
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Beck Arms
+  summary: Beck Arms (W2W)
   description: >
     Beck Arms is an apartment located in The Bronx, New York City.
     The building grows as R$ and R$$ on the New York tile set.

--- a/src/yaml/aaron-graham/bronx-collection.yaml
+++ b/src/yaml/aaron-graham/bronx-collection.yaml
@@ -1,0 +1,22 @@
+group: aaron-graham
+name: bronx-collection
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: The Bronx part of Aaron Graham's NYBT bats
+  descirption: >
+    Contains the Bronx part of Aaron Graham's NYBT collection.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file
+
+dependencies:
+  - "aaron-graham:1225-morris-avenue"
+  - "aaron-graham:25-e-193-street"
+  - "aaron-graham:2639-and-2641-jerome-avenue"
+  - "aaron-graham:655-e-228-street"
+  - "aaron-graham:barton-paul"
+  - "aaron-graham:concord-arms"
+  - "aaron-graham:walesbridge"
+  - "aaron-graham:kingsbridge-apartments"
+  - "aaron-graham:bainbridge-row"
+  - "aaron-graham:beck-arms"

--- a/src/yaml/aaron-graham/bronx-collection.yaml
+++ b/src/yaml/aaron-graham/bronx-collection.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 subfolder: 200-residential
 info:
   summary: The Bronx part of Aaron Graham's NYBT bats
-  descirption: >
+  description: >
     Contains the Bronx part of Aaron Graham's NYBT collection.
   author: Aaron Graham
   website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file

--- a/src/yaml/aaron-graham/brooklyn-collection.yaml
+++ b/src/yaml/aaron-graham/brooklyn-collection.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 subfolder: 200-residential
 info:
   summary: Brooklyn part of Aaron Graham's NYBT bats
-  descirption: >
+  description: >
     Contains the Brooklyn part of Aaron Graham's NYBT collection.
   author: Aaron Graham
   website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file

--- a/src/yaml/aaron-graham/brooklyn-collection.yaml
+++ b/src/yaml/aaron-graham/brooklyn-collection.yaml
@@ -1,0 +1,13 @@
+group: aaron-graham
+name: brooklyn-collection
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Brooklyn part of Aaron Graham's NYBT bats
+  descirption: >
+    Contains the Brooklyn part of Aaron Graham's NYBT collection.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file
+
+dependencies:
+  - "aaron-graham:tapscott-houses"

--- a/src/yaml/aaron-graham/complete-collection.yaml
+++ b/src/yaml/aaron-graham/complete-collection.yaml
@@ -14,7 +14,7 @@ info:
   website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file
 
 dependencies:
-  - "aaron-graham:manhttan-collection"
+  - "aaron-graham:manhattan-collection"
   - "aaron-graham:queens-collection"
   - "aaron-graham:brooklyn-collection"
   - "aaron-graham:bronx-collection"

--- a/src/yaml/aaron-graham/complete-collection.yaml
+++ b/src/yaml/aaron-graham/complete-collection.yaml
@@ -1,0 +1,21 @@
+group: aaron-graham
+name: complete-collection
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Complete collection of Aaron Graham's NYBT BATs
+  description: >
+    The collection consists of the Manhattan, Queens, Brooklyn, Bronx and fictitious collections.
+    You can install the entire collection or choose individual buildings by following the dependency links.
+
+    Note that some of Aaron's earliest BATs have been intentionally left out.
+    If you want those, you can get them from Simtropolis.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file
+
+dependencies:
+  - "aaron-graham:manhttan-collection"
+  - "aaron-graham:queens-collection"
+  - "aaron-graham:brooklyn-collection"
+  - "aaron-graham:bronx-collection"
+  - "aaron-graham:fictitious-collection"

--- a/src/yaml/aaron-graham/concord-arms.yaml
+++ b/src/yaml/aaron-graham/concord-arms.yaml
@@ -3,7 +3,7 @@ name: concord-arms
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Concord Arms
+  summary: Concord Arms (W2W)
   description: >
     Concord Arms is an apartment building located in The Bronx, New York City.
     The building grows as R$ and R$$ on the New York tile set.

--- a/src/yaml/aaron-graham/concord-arms.yaml
+++ b/src/yaml/aaron-graham/concord-arms.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: concord-arms
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Concord Arms
+  description: >
+    Concord Arms is an apartment building located in The Bronx, New York City.
+    The building grows as R$ and R$$ on the New York tile set.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/27036-nybt-concord-arms/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-concord-arms-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-concord-arms-maxisnite
+
+---
+assetId: aaron-graham-concord-arms-darknite
+version: "1.0"
+lastModified: "2011-12-10T20:57:28Z"
+url: https://community.simtropolis.com/files/file/27036-nybt-concord-arms/?do=download&r=95448&corner=true&where=The+Bronx
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-concord-arms-maxisnite
+version: "1.0"
+lastModified: "2011-12-10T20:57:28Z"
+url: https://community.simtropolis.com/files/file/27036-nybt-concord-arms/?do=download&r=95447&corner=true&where=The+Bronx
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/concord-arms.yaml
+++ b/src/yaml/aaron-graham/concord-arms.yaml
@@ -25,7 +25,7 @@ variants:
 assetId: aaron-graham-concord-arms-darknite
 version: "1.0"
 lastModified: "2011-12-10T20:57:28Z"
-url: https://community.simtropolis.com/files/file/27036-nybt-concord-arms/?do=download&r=95448&corner=true&where=The+Bronx
+url: https://community.simtropolis.com/files/file/27036-nybt-concord-arms/?do=download&r=95448
 archiveType:
   format: Clickteam
   version: "40"
@@ -34,7 +34,7 @@ archiveType:
 assetId: aaron-graham-concord-arms-maxisnite
 version: "1.0"
 lastModified: "2011-12-10T20:57:28Z"
-url: https://community.simtropolis.com/files/file/27036-nybt-concord-arms/?do=download&r=95447&corner=true&where=The+Bronx
+url: https://community.simtropolis.com/files/file/27036-nybt-concord-arms/?do=download&r=95447
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/dover-house.yaml
+++ b/src/yaml/aaron-graham/dover-house.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: dover-house
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Dover House
+  description: >
+    Dover House is a 1962 fourteen story apartment located in Manhattan, New York City.
+    The building grows as R$$ and R$$$ on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/28900-nybt-dover-house/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-dover-house-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-dover-house-maxisnite
+
+---
+assetId: aaron-graham-dover-house-darknite
+version: "1.0"
+lastModified: "2013-07-31T04:00:32Z"
+url: https://community.simtropolis.com/files/file/28900-nybt-dover-house/?do=download&r=120750
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-dover-house-maxisnite
+version: "1.0"
+lastModified: "2013-07-31T04:00:32Z"
+url: https://community.simtropolis.com/files/file/28900-nybt-dover-house/?do=download&r=120749
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/dover-house.yaml
+++ b/src/yaml/aaron-graham/dover-house.yaml
@@ -3,7 +3,7 @@ name: dover-house
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Dover House
+  summary: Dover House (W2W)
   description: >
     Dover House is a 1962 fourteen story apartment located in Manhattan, New York City.
     The building grows as R$$ and R$$$ in four color variations on the New York tile set.

--- a/src/yaml/aaron-graham/dover-house.yaml
+++ b/src/yaml/aaron-graham/dover-house.yaml
@@ -6,7 +6,7 @@ info:
   summary: Dover House
   description: >
     Dover House is a 1962 fourteen story apartment located in Manhattan, New York City.
-    The building grows as R$$ and R$$$ on the New York tile set.
+    The building grows as R$$ and R$$$ in four color variations on the New York tile set.
     It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/28900-nybt-dover-house/

--- a/src/yaml/aaron-graham/eyrene-apartments.yaml
+++ b/src/yaml/aaron-graham/eyrene-apartments.yaml
@@ -6,7 +6,7 @@ dependencies:
   - "nybt:essentials"
   - "bsc:mega-props-cp-vol01"
 info:
-  summary: Eyrene Apartments
+  summary: Eyrene Apartments (W2W)
   description: >
     Eyrene Apartments is a fictitious apartment inspired by New York City.
     The building grows as R$$ and R$$$ on the New York tile set.

--- a/src/yaml/aaron-graham/eyrene-apartments.yaml
+++ b/src/yaml/aaron-graham/eyrene-apartments.yaml
@@ -27,7 +27,7 @@ variants:
 assetId: aaron-graham-eyrene-apartments-darknite
 version: "1.0"
 lastModified: "2012-04-20T04:00:12Z"
-url: https://community.simtropolis.com/files/file/27493-eyrene-apartments/?do=download&r=107880&where=fictional
+url: https://community.simtropolis.com/files/file/27493-eyrene-apartments/?do=download&r=107880
 archiveType:
   format: Clickteam
   version: "30"
@@ -36,7 +36,7 @@ archiveType:
 assetId: aaron-graham-eyrene-apartments-maxisnite
 version: "1.0"
 lastModified: "2012-04-20T04:00:12Z"
-url: https://community.simtropolis.com/files/file/27493-eyrene-apartments/?do=download&r=107879&where=fictional
+url: https://community.simtropolis.com/files/file/27493-eyrene-apartments/?do=download&r=107879
 archiveType:
   format: Clickteam
   version: "30"

--- a/src/yaml/aaron-graham/eyrene-apartments.yaml
+++ b/src/yaml/aaron-graham/eyrene-apartments.yaml
@@ -2,6 +2,8 @@ group: aaron-graham
 name: eyrene-apartments
 version: "1.0"
 subfolder: 200-residential
+dependencies:
+  - "bsc:mega-props-cp-vol01"
 info:
   summary: Eyrene Apartments
   description: >

--- a/src/yaml/aaron-graham/eyrene-apartments.yaml
+++ b/src/yaml/aaron-graham/eyrene-apartments.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: eyrene-apartments
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Eyrene Apartments
+  description: >
+    Eyrene Apartments is a fictitious apartment inspired by New York City.
+    The building grows as R$$ and R$$$ on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/27493-eyrene-apartments/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-eyrene-apartments-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-eyrene-apartments-maxisnite
+
+---
+assetId: aaron-graham-eyrene-apartments-darknite
+version: "1.0"
+lastModified: "2012-04-20T04:00:12Z"
+url: https://community.simtropolis.com/files/file/27493-eyrene-apartments/?do=download&r=107880&where=fictional
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-eyrene-apartments-maxisnite
+version: "1.0"
+lastModified: "2012-04-20T04:00:12Z"
+url: https://community.simtropolis.com/files/file/27493-eyrene-apartments/?do=download&r=107879&where=fictional
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/eyrene-apartments.yaml
+++ b/src/yaml/aaron-graham/eyrene-apartments.yaml
@@ -3,6 +3,7 @@ name: eyrene-apartments
 version: "1.0"
 subfolder: 200-residential
 dependencies:
+  - "nybt:essentials"
   - "bsc:mega-props-cp-vol01"
 info:
   summary: Eyrene Apartments
@@ -13,7 +14,6 @@ info:
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/27493-eyrene-apartments/
 
-dependencies: ["nybt:essentials"]
 variants:
   - variant: { nightmode: dark }
     dependencies: ["simfox:day-and-nite-mod"]

--- a/src/yaml/aaron-graham/eyrene-apartments.yaml
+++ b/src/yaml/aaron-graham/eyrene-apartments.yaml
@@ -30,7 +30,7 @@ lastModified: "2012-04-20T04:00:12Z"
 url: https://community.simtropolis.com/files/file/27493-eyrene-apartments/?do=download&r=107880&where=fictional
 archiveType:
   format: Clickteam
-  version: "40"
+  version: "30"
 
 ---
 assetId: aaron-graham-eyrene-apartments-maxisnite
@@ -39,4 +39,4 @@ lastModified: "2012-04-20T04:00:12Z"
 url: https://community.simtropolis.com/files/file/27493-eyrene-apartments/?do=download&r=107879&where=fictional
 archiveType:
   format: Clickteam
-  version: "40"
+  version: "30"

--- a/src/yaml/aaron-graham/fictitious-collection.yaml
+++ b/src/yaml/aaron-graham/fictitious-collection.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 subfolder: 200-residential
 info:
   summary: Fictitious part of Aaron Graham's NYBT bats
-  descirption: >
+  description: >
     Contains the fictitious part of Aaron Graham's NYBT collection.
   author: Aaron Graham
   website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file

--- a/src/yaml/aaron-graham/fictitious-collection.yaml
+++ b/src/yaml/aaron-graham/fictitious-collection.yaml
@@ -1,0 +1,18 @@
+group: aaron-graham
+name: fictitious-collection
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Fictitious part of Aaron Graham's NYBT bats
+  descirption: >
+    Contains the fictitious part of Aaron Graham's NYBT collection.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file
+
+dependencies:
+  - "aaron-graham:aronic-place"
+  - "aaron-graham:eyrene-apartments"
+  - "aaron-graham:franklin-apartments"
+  - "aaron-graham:graham-apartments"
+  - "aaron-graham:hogan-apartments"
+  - "aaron-graham:johnson-apartments"

--- a/src/yaml/aaron-graham/franklin-apartments.yaml
+++ b/src/yaml/aaron-graham/franklin-apartments.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: franklin-apartments
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Franklin Apartments
+  description: >
+    Franklin Apartments is a fictitious apartment inspired by New York City.
+    The building grows as R$$ and R$$$ on the New York tile set.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/27149-franklin-apartments/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-franklin-apartments-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-franklin-apartments-maxisnite
+
+---
+assetId: aaron-graham-franklin-apartments-darknite
+version: "1.0"
+lastModified: "2012-01-06T08:23:08Z"
+url: https://community.simtropolis.com/files/file/27149-franklin-apartments/?do=download&r=95755&where=fictional&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-franklin-apartments-maxisnite
+version: "1.0"
+lastModified: "2012-01-06T08:23:08Z"
+url: https://community.simtropolis.com/files/file/27149-franklin-apartments/?do=download&r=95754&where=fictional&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/franklin-apartments.yaml
+++ b/src/yaml/aaron-graham/franklin-apartments.yaml
@@ -27,7 +27,7 @@ variants:
 assetId: aaron-graham-franklin-apartments-darknite
 version: "1.0"
 lastModified: "2012-01-06T08:23:08Z"
-url: https://community.simtropolis.com/files/file/27149-franklin-apartments/?do=download&r=95755&where=fictional&corner=true
+url: https://community.simtropolis.com/files/file/27149-franklin-apartments/?do=download&r=95755
 archiveType:
   format: Clickteam
   version: "40"
@@ -36,7 +36,7 @@ archiveType:
 assetId: aaron-graham-franklin-apartments-maxisnite
 version: "1.0"
 lastModified: "2012-01-06T08:23:08Z"
-url: https://community.simtropolis.com/files/file/27149-franklin-apartments/?do=download&r=95754&where=fictional&corner=true
+url: https://community.simtropolis.com/files/file/27149-franklin-apartments/?do=download&r=95754
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/franklin-apartments.yaml
+++ b/src/yaml/aaron-graham/franklin-apartments.yaml
@@ -3,6 +3,7 @@ name: franklin-apartments
 version: "1.0"
 subfolder: 200-residential
 dependencies:
+  - "nybt:essentials"
   - "bsc:texturepack-cycledogg-vol01"
 info:
   summary: Franklin Apartments
@@ -13,7 +14,6 @@ info:
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/27149-franklin-apartments/
 
-dependencies: ["nybt:essentials"]
 variants:
   - variant: { nightmode: dark }
     dependencies: ["simfox:day-and-nite-mod"]

--- a/src/yaml/aaron-graham/franklin-apartments.yaml
+++ b/src/yaml/aaron-graham/franklin-apartments.yaml
@@ -6,7 +6,7 @@ dependencies:
   - "nybt:essentials"
   - "bsc:texturepack-cycledogg-vol01"
 info:
-  summary: Franklin Apartments
+  summary: Franklin Apartments (W2W)
   description: >
     Franklin Apartments is a fictitious apartment inspired by New York City.
     The building grows as R$$ and R$$$ on the New York tile set.

--- a/src/yaml/aaron-graham/franklin-apartments.yaml
+++ b/src/yaml/aaron-graham/franklin-apartments.yaml
@@ -2,6 +2,8 @@ group: aaron-graham
 name: franklin-apartments
 version: "1.0"
 subfolder: 200-residential
+dependencies:
+  - "bsc:texturepack-cycledogg-vol01"
 info:
   summary: Franklin Apartments
   description: >

--- a/src/yaml/aaron-graham/graham-apartments.yaml
+++ b/src/yaml/aaron-graham/graham-apartments.yaml
@@ -3,7 +3,7 @@ name: graham-apartments
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Graham Apartments
+  summary: Graham Apartments (W2W)
   description: >
     Graham Apartments is a fictitious apartment inspired by New York City.
     The building grows as R$$ and R$$$ on the New York tile set.

--- a/src/yaml/aaron-graham/graham-apartments.yaml
+++ b/src/yaml/aaron-graham/graham-apartments.yaml
@@ -25,7 +25,7 @@ variants:
 assetId: aaron-graham-graham-apartments-darknite
 version: "1.0"
 lastModified: "2012-01-01T03:30:28Z"
-url: https://community.simtropolis.com/files/file/27123-graham-apartments/?do=download&r=95720&where=fictional&corner=true
+url: https://community.simtropolis.com/files/file/27123-graham-apartments/?do=download&r=95720
 archiveType:
   format: Clickteam
   version: "40"
@@ -34,7 +34,7 @@ archiveType:
 assetId: aaron-graham-graham-apartments-maxisnite
 version: "1.0"
 lastModified: "2012-01-01T03:30:28Z"
-url: https://community.simtropolis.com/files/file/27123-graham-apartments/?do=download&r=95719&where=fictional&corner=true
+url: https://community.simtropolis.com/files/file/27123-graham-apartments/?do=download&r=95719
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/graham-apartments.yaml
+++ b/src/yaml/aaron-graham/graham-apartments.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: graham-apartments
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Graham Apartments
+  description: >
+    Graham Apartments is a fictitious apartment inspired by New York City.
+    The building grows as R$$ and R$$$ on the New York tile set.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/27123-graham-apartments/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-graham-apartments-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-graham-apartments-maxisnite
+
+---
+assetId: aaron-graham-graham-apartments-darknite
+version: "1.0"
+lastModified: "2012-01-01T03:30:28Z"
+url: https://community.simtropolis.com/files/file/27123-graham-apartments/?do=download&r=95720&where=fictional&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-graham-apartments-maxisnite
+version: "1.0"
+lastModified: "2012-01-01T03:30:28Z"
+url: https://community.simtropolis.com/files/file/27123-graham-apartments/?do=download&r=95719&where=fictional&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/hattan-house.yaml
+++ b/src/yaml/aaron-graham/hattan-house.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: hattan-house
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Hattan House
+  description: >
+    Hattan House is a 1962 seventeen story apartment located in Manhattan, New York City.
+    The building grows as R$$, R$$$, CS$$ and CS$$$ in four color variations on the New York tileset.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/28414-nybt-hattan-house/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-hattan-house-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-hattan-house-maxisnite
+
+---
+assetId: aaron-graham-hattan-house-darknite
+version: "1.0"
+lastModified: "2013-02-01T05:15:25Z"
+url: https://community.simtropolis.com/files/file/28414-nybt-hattan-house/?do=download&r=111371&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-hattan-house-maxisnite
+version: "1.0"
+lastModified: "2013-02-01T05:15:25Z"
+url: https://community.simtropolis.com/files/file/28414-nybt-hattan-house/?do=download&r=111370&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/hattan-house.yaml
+++ b/src/yaml/aaron-graham/hattan-house.yaml
@@ -3,7 +3,7 @@ name: hattan-house
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Hattan House
+  summary: Hattan House (W2W)
   description: >
     Hattan House is a 1962 seventeen story apartment located in Manhattan, New York City.
     The building grows as R$$, R$$$, CS$$ and CS$$$ in four color variations on the New York tileset.

--- a/src/yaml/aaron-graham/hattan-house.yaml
+++ b/src/yaml/aaron-graham/hattan-house.yaml
@@ -25,7 +25,7 @@ variants:
 assetId: aaron-graham-hattan-house-darknite
 version: "1.0"
 lastModified: "2013-02-01T05:15:25Z"
-url: https://community.simtropolis.com/files/file/28414-nybt-hattan-house/?do=download&r=111371&corner=true
+url: https://community.simtropolis.com/files/file/28414-nybt-hattan-house/?do=download&r=111371
 archiveType:
   format: Clickteam
   version: "40"
@@ -34,7 +34,7 @@ archiveType:
 assetId: aaron-graham-hattan-house-maxisnite
 version: "1.0"
 lastModified: "2013-02-01T05:15:25Z"
-url: https://community.simtropolis.com/files/file/28414-nybt-hattan-house/?do=download&r=111370&corner=true
+url: https://community.simtropolis.com/files/file/28414-nybt-hattan-house/?do=download&r=111370
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/hogan-apartments.yaml
+++ b/src/yaml/aaron-graham/hogan-apartments.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: hogan-apartments
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Hogan Apartments
+  description: >
+    Hogan Apartments is a fictitious apartment inspired by New York City.
+    The building grows as R$$ and R$$$ on the New York tile set.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/27204-hogan-apartments/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-hogan-apartments-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-hogan-apartments-maxisnite
+
+---
+assetId: aaron-graham-hogan-apartments-darknite
+version: "1.0"
+lastModified: "2012-01-20T05:59:24Z"
+url: https://community.simtropolis.com/files/file/27204-hogan-apartments/?do=download&r=96260&where=fictional
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-hogan-apartments-maxisnite
+version: "1.0"
+lastModified: "2012-01-20T05:59:24Z"
+url: https://community.simtropolis.com/files/file/27204-hogan-apartments/?do=download&r=96259&where=fictional
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/hogan-apartments.yaml
+++ b/src/yaml/aaron-graham/hogan-apartments.yaml
@@ -2,6 +2,8 @@ group: aaron-graham
 name: hogan-apartments
 version: "1.0"
 subfolder: 200-residential
+dependencies:
+  - "bsc:texturepack-cycledogg-vol01"
 info:
   summary: Hogan Apartments
   description: >

--- a/src/yaml/aaron-graham/hogan-apartments.yaml
+++ b/src/yaml/aaron-graham/hogan-apartments.yaml
@@ -6,7 +6,7 @@ dependencies:
   - "nybt:essentials"
   - "bsc:texturepack-cycledogg-vol01"
 info:
-  summary: Hogan Apartments
+  summary: Hogan Apartments (W2W)
   description: >
     Hogan Apartments is a fictitious apartment inspired by New York City.
     The building grows as R$$ and R$$$ on the New York tile set.

--- a/src/yaml/aaron-graham/hogan-apartments.yaml
+++ b/src/yaml/aaron-graham/hogan-apartments.yaml
@@ -3,6 +3,7 @@ name: hogan-apartments
 version: "1.0"
 subfolder: 200-residential
 dependencies:
+  - "nybt:essentials"
   - "bsc:texturepack-cycledogg-vol01"
 info:
   summary: Hogan Apartments
@@ -13,7 +14,6 @@ info:
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/27204-hogan-apartments/
 
-dependencies: ["nybt:essentials"]
 variants:
   - variant: { nightmode: dark }
     dependencies: ["simfox:day-and-nite-mod"]

--- a/src/yaml/aaron-graham/hogan-apartments.yaml
+++ b/src/yaml/aaron-graham/hogan-apartments.yaml
@@ -27,7 +27,7 @@ variants:
 assetId: aaron-graham-hogan-apartments-darknite
 version: "1.0"
 lastModified: "2012-01-20T05:59:24Z"
-url: https://community.simtropolis.com/files/file/27204-hogan-apartments/?do=download&r=96260&where=fictional
+url: https://community.simtropolis.com/files/file/27204-hogan-apartments/?do=download&r=96260
 archiveType:
   format: Clickteam
   version: "40"
@@ -36,7 +36,7 @@ archiveType:
 assetId: aaron-graham-hogan-apartments-maxisnite
 version: "1.0"
 lastModified: "2012-01-20T05:59:24Z"
-url: https://community.simtropolis.com/files/file/27204-hogan-apartments/?do=download&r=96259&where=fictional
+url: https://community.simtropolis.com/files/file/27204-hogan-apartments/?do=download&r=96259
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/johnson-apartments.yaml
+++ b/src/yaml/aaron-graham/johnson-apartments.yaml
@@ -30,7 +30,7 @@ lastModified: "2012-04-13T04:00:08Z"
 url: https://community.simtropolis.com/files/file/27463-johnson-apartments/?do=download&r=99612&where=fictional
 archiveType:
   format: Clickteam
-  version: "40"
+  version: "30"
 
 ---
 assetId: aaron-graham-johnson-apartments-maxisnite
@@ -39,4 +39,4 @@ lastModified: "2012-04-13T04:00:08Z"
 url: https://community.simtropolis.com/files/file/27463-johnson-apartments/?do=download&r=99611&where=fictional
 archiveType:
   format: Clickteam
-  version: "40"
+  version: "30"

--- a/src/yaml/aaron-graham/johnson-apartments.yaml
+++ b/src/yaml/aaron-graham/johnson-apartments.yaml
@@ -6,7 +6,7 @@ dependencies:
   - "nybt:essentials"
   - "bsc:mega-props-cp-vol01"
 info:
-  summary: Johnson Apartments
+  summary: Johnson Apartments (W2W)
   description: >
     Johnson Apartments is a fictitious apartment inspired by New York City.
     The building grows as R$$ and R$$$ on the New York tile set.

--- a/src/yaml/aaron-graham/johnson-apartments.yaml
+++ b/src/yaml/aaron-graham/johnson-apartments.yaml
@@ -27,7 +27,7 @@ variants:
 assetId: aaron-graham-johnson-apartments-darknite
 version: "1.0"
 lastModified: "2012-04-13T04:00:08Z"
-url: https://community.simtropolis.com/files/file/27463-johnson-apartments/?do=download&r=99612&where=fictional
+url: https://community.simtropolis.com/files/file/27463-johnson-apartments/?do=download&r=99612
 archiveType:
   format: Clickteam
   version: "30"
@@ -36,7 +36,7 @@ archiveType:
 assetId: aaron-graham-johnson-apartments-maxisnite
 version: "1.0"
 lastModified: "2012-04-13T04:00:08Z"
-url: https://community.simtropolis.com/files/file/27463-johnson-apartments/?do=download&r=99611&where=fictional
+url: https://community.simtropolis.com/files/file/27463-johnson-apartments/?do=download&r=99611
 archiveType:
   format: Clickteam
   version: "30"

--- a/src/yaml/aaron-graham/johnson-apartments.yaml
+++ b/src/yaml/aaron-graham/johnson-apartments.yaml
@@ -3,6 +3,7 @@ name: johnson-apartments
 version: "1.0"
 subfolder: 200-residential
 dependencies:
+  - "nybt:essentials"
   - "bsc:mega-props-cp-vol01"
 info:
   summary: Johnson Apartments
@@ -13,7 +14,6 @@ info:
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/27463-johnson-apartments/
 
-dependencies: ["nybt:essentials"]
 variants:
   - variant: { nightmode: dark }
     dependencies: ["simfox:day-and-nite-mod"]

--- a/src/yaml/aaron-graham/johnson-apartments.yaml
+++ b/src/yaml/aaron-graham/johnson-apartments.yaml
@@ -2,6 +2,8 @@ group: aaron-graham
 name: johnson-apartments
 version: "1.0"
 subfolder: 200-residential
+dependencies:
+  - "bsc:mega-props-cp-vol01"
 info:
   summary: Johnson Apartments
   description: >

--- a/src/yaml/aaron-graham/johnson-apartments.yaml
+++ b/src/yaml/aaron-graham/johnson-apartments.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: johnson-apartments
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Johnson Apartments
+  description: >
+    Johnson Apartments is a fictitious apartment inspired by New York City.
+    The building grows as R$$ and R$$$ on the New York tile set.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/27463-johnson-apartments/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-johnson-apartments-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-johnson-apartments-maxisnite
+
+---
+assetId: aaron-graham-johnson-apartments-darknite
+version: "1.0"
+lastModified: "2012-04-13T04:00:08Z"
+url: https://community.simtropolis.com/files/file/27463-johnson-apartments/?do=download&r=99612&where=fictional
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-johnson-apartments-maxisnite
+version: "1.0"
+lastModified: "2012-04-13T04:00:08Z"
+url: https://community.simtropolis.com/files/file/27463-johnson-apartments/?do=download&r=99611&where=fictional
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/kingsbridge-apartments.yaml
+++ b/src/yaml/aaron-graham/kingsbridge-apartments.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: kingsbridge-apartments
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Kingsbridge Apartments
+  description: >
+    Kingsbridge Apartments is an apartment located in The Bronx, New York City.
+    The building grows as R$ and R$$ on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/26394-nybt-kingsbridge-apartments/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-kingsbridge-apartments-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-kingsbridge-apartments-maxisnite
+
+---
+assetId: aaron-graham-kingsbridge-apartments-darknite
+version: "1.0"
+lastModified: "2011-09-29T14:06:07Z"
+url: https://community.simtropolis.com/files/file/26394-nybt-kingsbridge-apartments/?do=download&r=95748&where=The+Bronx
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-kingsbridge-apartments-maxisnite
+version: "1.0"
+lastModified: "2011-09-29T14:06:07Z"
+url: https://community.simtropolis.com/files/file/26394-nybt-kingsbridge-apartments/?do=download&r=95747&where=The+Bronx
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/kingsbridge-apartments.yaml
+++ b/src/yaml/aaron-graham/kingsbridge-apartments.yaml
@@ -25,7 +25,7 @@ variants:
 assetId: aaron-graham-kingsbridge-apartments-darknite
 version: "1.0"
 lastModified: "2011-09-29T14:06:07Z"
-url: https://community.simtropolis.com/files/file/26394-nybt-kingsbridge-apartments/?do=download&r=95748&where=The+Bronx
+url: https://community.simtropolis.com/files/file/26394-nybt-kingsbridge-apartments/?do=download&r=95748
 archiveType:
   format: Clickteam
   version: "40"
@@ -34,7 +34,7 @@ archiveType:
 assetId: aaron-graham-kingsbridge-apartments-maxisnite
 version: "1.0"
 lastModified: "2011-09-29T14:06:07Z"
-url: https://community.simtropolis.com/files/file/26394-nybt-kingsbridge-apartments/?do=download&r=95747&where=The+Bronx
+url: https://community.simtropolis.com/files/file/26394-nybt-kingsbridge-apartments/?do=download&r=95747
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/kingsbridge-apartments.yaml
+++ b/src/yaml/aaron-graham/kingsbridge-apartments.yaml
@@ -3,7 +3,7 @@ name: kingsbridge-apartments
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Kingsbridge Apartments
+  summary: Kingsbridge Apartments (W2W)
   description: >
     Kingsbridge Apartments is an apartment located in The Bronx, New York City.
     The building grows as R$ and R$$ on the New York tile set.

--- a/src/yaml/aaron-graham/manhattan-collection.yaml
+++ b/src/yaml/aaron-graham/manhattan-collection.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 subfolder: 200-residential
 info:
   summary: Manhattan part of Aaron Graham's NYBT bats
-  descirption: >
+  description: >
     Contains the Manhattan part of Aaron Graham's NYBT collection.
   author: Aaron Graham
   website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file

--- a/src/yaml/aaron-graham/manhattan-collection.yaml
+++ b/src/yaml/aaron-graham/manhattan-collection.yaml
@@ -1,0 +1,23 @@
+group: aaron-graham
+name: manhattan-collection
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Manhattan part of Aaron Graham's NYBT bats
+  descirption: >
+    Contains the Manhattan part of Aaron Graham's NYBT collection.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file
+
+dependencies:
+  - "aaron-graham:201-e-19-street"
+  - "aaron-graham:30-e-81-street"
+  - "aaron-graham:41-park-avenue"
+  - "aaron-graham:605-park-avenue"
+  - "aaron-graham:785-park-avenue"
+  - "aaron-graham:915-west-end-avenue"
+  - "aaron-graham:dover-house"
+  - "aaron-graham:gracie-manor"
+  - "aaron-graham:hattan-house"
+  - "aaron-graham:townsley"
+  - "aaron-graham:worthington-apartments"

--- a/src/yaml/aaron-graham/queens-collection.yaml
+++ b/src/yaml/aaron-graham/queens-collection.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 subfolder: 200-residential
 info:
   summary: Queens part of Aaron Graham's NYBT bats
-  descirption: >
+  description: >
     Contains the Queens part of Aaron Graham's NYBT collection.
   author: Aaron Graham
   website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file

--- a/src/yaml/aaron-graham/queens-collection.yaml
+++ b/src/yaml/aaron-graham/queens-collection.yaml
@@ -1,0 +1,13 @@
+group: aaron-graham
+name: queens-collection
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Queens part of Aaron Graham's NYBT bats
+  descirption: >
+    Contains the Queens part of Aaron Graham's NYBT collection.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file
+
+dependencies:
+  - "aaron-graham:32-48-30th-street"

--- a/src/yaml/aaron-graham/tapscott-houses.yaml
+++ b/src/yaml/aaron-graham/tapscott-houses.yaml
@@ -3,7 +3,7 @@ name: tapscott-houses
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Tapscott Houses
+  summary: Tapscott Houses (W2W)
   description: >
     Tapscott Houses is an apartment located in Brooklyn, New York City.
     The building grows as R$ and R$$ on the New York tile set.

--- a/src/yaml/aaron-graham/tapscott-houses.yaml
+++ b/src/yaml/aaron-graham/tapscott-houses.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: tapscott-houses
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Tapscott Houses
+  description: >
+    Tapscott Houses is an apartment located in Brooklyn, New York City.
+    The building grows as R$ and R$$ on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/26544-nybt-tapscott-houses/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-tapscott-houses-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-tapscott-houses-maxisnite
+
+---
+assetId: aaron-graham-tapscott-houses-darknite
+version: "1.0"
+lastModified: "2011-07-22T04:13:09Z"
+url: https://community.simtropolis.com/files/file/26544-nybt-tapscott-houses/?do=download&r=95727&where=Brooklyn
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-tapscott-houses-maxisnite
+version: "1.0"
+lastModified: "2011-07-22T04:13:09Z"
+url: https://community.simtropolis.com/files/file/26544-nybt-tapscott-houses/?do=download&r=95726&where=Brooklyn
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/tapscott-houses.yaml
+++ b/src/yaml/aaron-graham/tapscott-houses.yaml
@@ -25,7 +25,7 @@ variants:
 assetId: aaron-graham-tapscott-houses-darknite
 version: "1.0"
 lastModified: "2011-07-22T04:13:09Z"
-url: https://community.simtropolis.com/files/file/26544-nybt-tapscott-houses/?do=download&r=95727&where=Brooklyn
+url: https://community.simtropolis.com/files/file/26544-nybt-tapscott-houses/?do=download&r=95727
 archiveType:
   format: Clickteam
   version: "40"
@@ -34,7 +34,7 @@ archiveType:
 assetId: aaron-graham-tapscott-houses-maxisnite
 version: "1.0"
 lastModified: "2011-07-22T04:13:09Z"
-url: https://community.simtropolis.com/files/file/26544-nybt-tapscott-houses/?do=download&r=95726&where=Brooklyn
+url: https://community.simtropolis.com/files/file/26544-nybt-tapscott-houses/?do=download&r=95726
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/townsley.yaml
+++ b/src/yaml/aaron-graham/townsley.yaml
@@ -3,7 +3,7 @@ name: townsley
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Townsley
+  summary: Townsley (W2W)
   description: >
     Townsley is a 1964 fifteen story apartment located in Manhattan, New York City.
     The building grows as R$$ and R$$$ in four color variations on the New York tile set.

--- a/src/yaml/aaron-graham/townsley.yaml
+++ b/src/yaml/aaron-graham/townsley.yaml
@@ -6,7 +6,7 @@ info:
   summary: Townsley
   description: >
     Townsley is a 1964 fifteen story apartment located in Manhattan, New York City.
-    The building grows as R$$ and R$$$ on the New York tile set.
+    The building grows as R$$ and R$$$ in four color variations on the New York tile set.
     It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
   author: Aaron Graham
   website: https://community.simtropolis.com/files/file/29031-nybt-townsley/

--- a/src/yaml/aaron-graham/townsley.yaml
+++ b/src/yaml/aaron-graham/townsley.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: townsley
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Townsley
+  description: >
+    Townsley is a 1964 fifteen story apartment located in Manhattan, New York City.
+    The building grows as R$$ and R$$$ on the New York tile set.
+    It is a (W2W) wall to wall building and will fit perfectly in the middle of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/29031-nybt-townsley/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-townsley-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-townsley-maxisnite
+
+---
+assetId: aaron-graham-townsley-darknite
+version: "1.0"
+lastModified: "2013-10-31T13:59:28Z"
+url: https://community.simtropolis.com/files/file/29031-nybt-townsley/?do=download&r=120762
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-townsley-maxisnite
+version: "1.0"
+lastModified: "2013-10-31T13:59:28Z"
+url: https://community.simtropolis.com/files/file/29031-nybt-townsley/?do=download&r=120761
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/walesbridge.yaml
+++ b/src/yaml/aaron-graham/walesbridge.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: walesbridge
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Walesbridge
+  description: >
+    Walesbridge is a 1940-1950s six story apartment located in The Bronx, New York City.
+    The building grows as R$ and R$$ on the New York tile set.
+    There are eight variations in total: four corner buildings and four non-corner buildings, each with four different brick colors.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/28321-nybt-walesbridge/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-walesbridge-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-walesbridge-maxisnite
+
+---
+assetId: aaron-graham-walesbridge-darknite
+version: "1.0"
+lastModified: "2012-12-25T10:16:34Z"
+url: https://community.simtropolis.com/files/file/28321-nybt-walesbridge/?do=download&r=110163
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-walesbridge-maxisnite
+version: "1.0"
+lastModified: "2012-12-25T10:16:34Z"
+url: https://community.simtropolis.com/files/file/28321-nybt-walesbridge/?do=download&r=110162
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/aaron-graham/worthington-apartments.yaml
+++ b/src/yaml/aaron-graham/worthington-apartments.yaml
@@ -3,7 +3,7 @@ name: worthington-apartments
 version: "1.0"
 subfolder: 200-residential
 info:
-  summary: Worthington Apartments
+  summary: Worthington Apartments (W2W)
   description: >
     Worthington Apartments is an apartment building based on 888 Park Avenue located in Manhattan, New York City.
     The building grows as R$$ and R$$$ on the New York and Chicago tile sets.

--- a/src/yaml/aaron-graham/worthington-apartments.yaml
+++ b/src/yaml/aaron-graham/worthington-apartments.yaml
@@ -25,7 +25,7 @@ variants:
 assetId: aaron-graham-worthington-apartments-darknite
 version: "1.0"
 lastModified: "2012-10-23T04:55:51Z"
-url: https://community.simtropolis.com/files/file/28152-worthington-apartments/?do=download&r=108055&corner=true
+url: https://community.simtropolis.com/files/file/28152-worthington-apartments/?do=download&r=108055
 archiveType:
   format: Clickteam
   version: "40"
@@ -34,7 +34,7 @@ archiveType:
 assetId: aaron-graham-worthington-apartments-maxisnite
 version: "1.0"
 lastModified: "2012-10-23T04:55:51Z"
-url: https://community.simtropolis.com/files/file/28152-worthington-apartments/?do=download&r=108054&corner=true
+url: https://community.simtropolis.com/files/file/28152-worthington-apartments/?do=download&r=108054
 archiveType:
   format: Clickteam
   version: "40"

--- a/src/yaml/aaron-graham/worthington-apartments.yaml
+++ b/src/yaml/aaron-graham/worthington-apartments.yaml
@@ -1,0 +1,40 @@
+group: aaron-graham
+name: worthington-apartments
+version: "1.0"
+subfolder: 200-residential
+info:
+  summary: Worthington Apartments
+  description: >
+    Worthington Apartments is an apartment building based on 888 Park Avenue located in Manhattan, New York City.
+    The building grows as R$$ and R$$$ on the New York and Chicago tile sets.
+    It is a (W2W) wall to wall corner building and will fit perfectly on the end of your city block.
+  author: Aaron Graham
+  website: https://community.simtropolis.com/files/file/28152-worthington-apartments/
+
+dependencies: ["nybt:essentials"]
+variants:
+  - variant: { nightmode: dark }
+    dependencies: ["simfox:day-and-nite-mod"]
+    assets:
+      - assetId: aaron-graham-worthington-apartments-darknite
+  - variant: { nightmode: standard }
+    assets:
+      - assetId: aaron-graham-worthington-apartments-maxisnite
+
+---
+assetId: aaron-graham-worthington-apartments-darknite
+version: "1.0"
+lastModified: "2012-10-23T04:55:51Z"
+url: https://community.simtropolis.com/files/file/28152-worthington-apartments/?do=download&r=108055&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"
+
+---
+assetId: aaron-graham-worthington-apartments-maxisnite
+version: "1.0"
+lastModified: "2012-10-23T04:55:51Z"
+url: https://community.simtropolis.com/files/file/28152-worthington-apartments/?do=download&r=108054&corner=true
+archiveType:
+  format: Clickteam
+  version: "40"


### PR DESCRIPTION
This adds metadata for [all of Aaron Graham's BATs](https://community.simtropolis.com/profile/226625-aaron-graham/content/?type=downloads_file), except for a few early ones that have been left out intentionally.

It looks like cicdec is extracting everything nicely, except for 1 package: the Maxis nite version of [41 Park Avenue](https://community.simtropolis.com/files/file/27913-nybt-41-park-avenue/) fails to extract properly. @memo33 could you check if this happens with you on Linux as well? If I run cicdec manually on the installer, it gives me the following error:

```
cicdec -v 40 "Install NYBT 41 Park Avenue (Maxis Nite).exe"
cicdec - A Clickteam Install Creator unpacker by Bioruebe (https://bioruebe.com), 2019-2021, Version 3.0.1, Released under a BSD 3-Clause style license

Extracts files from installers made with Clickteam Install Creator

Usage: cicdec [<options>...] <installer> [<output_directory>]

<options>:
  -v <version>  Extract as installer version <version>. Auto-detection might not always work correctly, so it is possible to explicitly set the installer version.

  -db   Dump blocks. Save additional installer data like registry changes, license files and the uninstaller. This is considered raw data and might not be readable or usable.

  -dfb  Dump file block. This is raw binary data containing all files in compressed form and only useful for debugging purposes.

  -si   Simulate extraction without writing files to disk.

---------------------------------------------------------------------
Starting extraction at offset 139270

Reading block 0x1435 UNKNOWN_FONT     with size 617
Reading block 0x1436 UNKNOWN_DATA     with size 107329
Reading block 0x143E STRINGS          with size 1651
Reading block 0x1445 REGISTRY_CHANGES with size 128
Reading block 0x143A FILE_LIST        with size 538
Reading block 0x7F7F FILE_DATA        with size 4986159
Reading block 0x152F 5423             with size 1750745602

11 files in installer


Starting extraction as installer version 40

1/11    4Model


The file C:\Users\sebam\Documents\SimCity 4\sc4pac\cicdec\Install NYBT 41 Park Avenue (Maxis Nite)\4Model already exists. Overwrite? [y]es | [N]o | [r]ename | [a]lways | n[e]ver | rename a[l]l
y
[WARNING] Failed to decompress file, exception was Ongeldige Win32 FileTime.
2/11    4Model


The file C:\Users\sebam\Documents\SimCity 4\sc4pac\cicdec\Install NYBT 41 Park Avenue (Maxis Nite)\4Model already exists. Overwrite? [y]es | [N]o | [r]ename | [a]lways | n[e]ver | rename a[l]l
y
[WARNING] Failed to decompress file, exception was Ongeldige Win32 FileTime.
3/11    4Model


The file C:\Users\sebam\Documents\SimCity 4\sc4pac\cicdec\Install NYBT 41 Park Avenue (Maxis Nite)\4Model already exists. Overwrite? [y]es | [N]o | [r]ename | [a]lways | n[e]ver | rename a[l]l
y
[WARNING] Failed to decompress file, exception was Ongeldige Win32 FileTime.
4/11    4Model


The file C:\Users\sebam\Documents\SimCity 4\sc4pac\cicdec\Install NYBT 41 Park Avenue (Maxis Nite)\4Model already exists. Overwrite? [y]es | [N]o | [r]ename | [a]lways | n[e]ver | rename a[l]l
y
[WARNING] Failed to decompress file, exception was Ongeldige Win32 FileTime.
5/11    .dat
[WARNING] Failed to decompress file, exception was Ongeldige Win32 FileTime.
6/11    dat
[WARNING] Failed to decompress file, exception was Ongeldige Win32 FileTime.
7/11    images\Dark Night.jpg
8/11    images\Day.jpg
9/11    images\Night.jpg
10/11   NYBT 41 Park Avenue Read Me.html
11/11   NYBT Banner01.png
[WARNING] 6 files failed to extract
```

Looks like it fails to extract the .dat files. I'm wondering whether this is just a Windows issue, or an issue with cicdec.