### PR TITLE
Add various metadata

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -123,6 +123,7 @@ Many additional civic buildings by mattb325 are listed at [Channel](channel/ ':t
 * `pkg=memo:submenus-dll` (adds more submenus to the game)
 * `pkg=cam:colossus-addon-mod` (adds more growth stages to the game)
 * `pkg=nam-team:tunnel-and-slope-mod` (smooth slopes for networks)
+* `pkg=warrior:god-terraforming-in-mayor-mode` (more convenient access to god tools)
 
 ## Dependency packs
 

--- a/src/yaml/andisart/tower-verre-53w53.yaml
+++ b/src/yaml/andisart/tower-verre-53w53.yaml
@@ -1,9 +1,9 @@
 group: andisart
-name: tower-verre-53w53
+name: tower-verre
 version: "1.0"
 subfolder: 360-landmark
 info:
-  summary: Tower Verre - 53W53
+  summary: Tower Verre - 53W53 (MoMA Expansion Tower)
   description: |
     - Origin: Midtown, New York City
     - Construction: 2014 - 2018
@@ -13,23 +13,8 @@ info:
 
     Contains 3 different lots:
      - Landmark
-      - Plop Cost: 187.000
-      - Monthly Cost: 150
-      - Mayor Rating: Value: 10, Radius: 256
-      - Found in Landmark menu, sorted by plop cost
-
-     - Growable
-      - Residents: 2030 R$$$
-      - Tilesets: New York, Chicago
-      - Growth Stage: 8
-
+     - Growable R$$$ (Tilesets: New York, Chicago)
      - Plobbable with Jobs
-      - CS Jobs: 310 ($$$)
-      - Plop Cost: 187.000
-
-    Found in Landmark menu, sorted by plop cost
-    For the growable version you need to zone high density zones.
-    The ploppable version is functional just as the growable and is located in the "Landmarks" menu.
 
   author: AndisArt
   website: https://community.simtropolis.com/files/file/32106-tower-verre-53w53/

--- a/src/yaml/andisart/tower-verre-53w53.yaml
+++ b/src/yaml/andisart/tower-verre-53w53.yaml
@@ -11,13 +11,13 @@ info:
     - Architect: Jean Nouvel
     - Lot Size: 4x2
 
-    Contains 3 different lots:  
+    Contains 3 different lots:
      - Landmark
       - Plop Cost: 187.000
       - Monthly Cost: 150
       - Mayor Rating: Value: 10, Radius: 256
       - Found in Landmark menu, sorted by plop cost
-    
+
      - Growable
       - Residents: 2030 R$$$
       - Tilesets: New York, Chicago
@@ -26,7 +26,7 @@ info:
      - Plobbable with Jobs
       - CS Jobs: 310 ($$$)
       - Plop Cost: 187.000
-    
+
     Found in Landmark menu, sorted by plop cost
     For the growable version you need to zone high density zones.
     The ploppable version is functional just as the growable and is located in the "Landmarks" menu.

--- a/src/yaml/andreas-roth/bart-talent-elevated-and-subway-train.yaml
+++ b/src/yaml/andreas-roth/bart-talent-elevated-and-subway-train.yaml
@@ -1,0 +1,22 @@
+group: andreas-roth
+name: bart-talent-elevated-and-subway-train
+version: "1.0"
+subfolder: 710-automata
+info:
+  summary: BART Talent elevated and subway train
+  description: |
+    This mod will replace the original el-train/subway cars.
+  author: Andreas Roth
+  website: https://community.simtropolis.com/files/file/11779-bart-talent-elevated-and-subway-train/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_02_2005/thumb-8a9b2c4bfad315377d91eefc23d05ef8-andreas_el-train_talent_bart1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2005/thumb-8a9b2c4bfad315377d91eefc23d05ef8-andreas_el-train_talent_bart2.jpg
+
+assets:
+  - assetId: andreas-roth-bart-talent-elevated-and-subway-train
+
+---
+assetId: andreas-roth-bart-talent-elevated-and-subway-train
+version: "1.0"
+lastModified: "2005-02-26T01:06:38Z"
+url: https://community.simtropolis.com/files/file/11779-bart-talent-elevated-and-subway-train/?do=download

--- a/src/yaml/andreas/bart-talent-elevated-and-subway-train.yaml
+++ b/src/yaml/andreas/bart-talent-elevated-and-subway-train.yaml
@@ -1,4 +1,4 @@
-group: andreas-roth
+group: andreas
 name: bart-talent-elevated-and-subway-train
 version: "1.0"
 subfolder: 710-automata
@@ -6,17 +6,17 @@ info:
   summary: BART Talent elevated and subway train
   description: |
     This mod will replace the original el-train/subway cars.
-  author: Andreas Roth
+  author: Andreas
   website: https://community.simtropolis.com/files/file/11779-bart-talent-elevated-and-subway-train/
   images:
     - https://www.simtropolis.com/objects/screens/monthly_02_2005/thumb-8a9b2c4bfad315377d91eefc23d05ef8-andreas_el-train_talent_bart1.jpg
     - https://www.simtropolis.com/objects/screens/monthly_02_2005/thumb-8a9b2c4bfad315377d91eefc23d05ef8-andreas_el-train_talent_bart2.jpg
 
 assets:
-  - assetId: andreas-roth-bart-talent-elevated-and-subway-train
+  - assetId: andreas-bart-talent-elevated-and-subway-train
 
 ---
-assetId: andreas-roth-bart-talent-elevated-and-subway-train
+assetId: andreas-bart-talent-elevated-and-subway-train
 version: "1.0"
 lastModified: "2005-02-26T01:06:38Z"
 url: https://community.simtropolis.com/files/file/11779-bart-talent-elevated-and-subway-train/?do=download

--- a/src/yaml/dmscopio/guangzhou-twin-tower-v2.yaml
+++ b/src/yaml/dmscopio/guangzhou-twin-tower-v2.yaml
@@ -1,5 +1,5 @@
 group: dmscopio
-name: guangzhou-twin-tower-v2
+name: guangzhou-twin-tower
 version: "2"
 subfolder: 300-commercial
 info:
@@ -13,21 +13,22 @@ info:
     - https://www.simtropolis.com/objects/screens/0001/05b1c0d328ad22224caab81f2dee9c25-GZTwinNightupload.jpg
 
 dependencies:
+  - bsc:essentials  # should include old CAM essentials
   - bsc:textures-vol01
   - bsc:textures-vol02
 
 variants:
   - variant: { CAM: "no" }
     assets:
-      - assetId: dmscopio-guangzhou-twin-tower-v2
+      - assetId: dmscopio-guangzhou-twin-tower
         exclude:
           - "CO\\$\\$15"
   - variant: { CAM: "yes" }
     assets:
-      - assetId: dmscopio-guangzhou-twin-tower-v2
+      - assetId: dmscopio-guangzhou-twin-tower
 
 ---
-assetId: dmscopio-guangzhou-twin-tower-v2
+assetId: dmscopio-guangzhou-twin-tower
 version: "2"
 lastModified: "2007-09-16T04:15:59Z"
 url: https://community.simtropolis.com/files/file/18671-guangzhou-twin-tower-v2/?do=download

--- a/src/yaml/dmscopio/guangzhou-twin-tower-v2.yaml
+++ b/src/yaml/dmscopio/guangzhou-twin-tower-v2.yaml
@@ -5,7 +5,7 @@ subfolder: 300-commercial
 info:
   summary: Guangzhou Twin Tower V2
   description: |
-    The Guangzhou Twin Tower comes as a ploppable landmark with CO$$$ jobs and also as a CO$$ stage 15 growable CAMeLot. 
+    The Guangzhou Twin Tower comes as a ploppable landmark with CO$$$ jobs and also as a CO$$ stage 15 growable CAMeLot.
   author: dmscopio
   website: https://community.simtropolis.com/files/file/18671-guangzhou-twin-tower-v2/
   images:

--- a/src/yaml/dmscopio/soccer-city-stadium-by-dmscopio.yaml
+++ b/src/yaml/dmscopio/soccer-city-stadium-by-dmscopio.yaml
@@ -1,0 +1,32 @@
+group: dmscopio
+name: soccer-city-stadium
+version: "1.0"
+subfolder: 360-landmark
+info:
+  summary: Soccer City Stadium
+  description: |
+    First National Bank Stadium or simply FNB Stadium, also known as Soccer City and The Calabash, is a stadium located in Nasrec, the Soweto area of Johannesburg, South Africa.
+    Designed as the main association football stadium for the World Cup, the FNB Stadium became the largest stadium in Africa with a capacity of 94,736. 
+    
+    Statistics
+    Lot size: 18 x 18
+    Cost: Free
+  author: DmScopio
+  website: https://community.simtropolis.com/files/file/28813-soccer-city-stadium-by-dmscopio
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_06_2013/thumb-7182495203dcae06e9685f124330b09b-soccer-city.jpeg
+    - https://www.simtropolis.com/objects/screens/monthly_06_2013/thumb-a73d1c07d4aa7869d03de70a8ee75e02-bangara-16-jan--711372331034.png
+    - https://www.simtropolis.com/objects/screens/monthly_06_2013/thumb-53916158c22809fa72e5180f1b6b2496-bangara-2-mar--711372331061.png
+    - https://www.simtropolis.com/objects/screens/monthly_06_2013/thumb-64f74ae3f49471fdba43140c8710dd8e-soccer_city_in_johannesburg.jpg
+
+dependencies:
+  - bsc:textures-vol01
+
+assets:
+- assetId: dmscopio-soccer-city-stadium-by-dmscopio
+
+---
+assetId: dmscopio-soccer-city-stadium-by-dmscopio
+version: "1.0"
+lastModified: "2013-06-27T11:25:13Z"
+url: https://community.simtropolis.com/files/file/28813-soccer-city-stadium-by-dmscopio?do=download

--- a/src/yaml/dmscopio/soccer-city-stadium-by-dmscopio.yaml
+++ b/src/yaml/dmscopio/soccer-city-stadium-by-dmscopio.yaml
@@ -23,7 +23,7 @@ dependencies:
   - bsc:textures-vol01
 
 assets:
-- assetId: dmscopio-soccer-city-stadium-by-dmscopio
+  - assetId: dmscopio-soccer-city-stadium-by-dmscopio
 
 ---
 assetId: dmscopio-soccer-city-stadium-by-dmscopio

--- a/src/yaml/dmscopio/soccer-city-stadium-by-dmscopio.yaml
+++ b/src/yaml/dmscopio/soccer-city-stadium-by-dmscopio.yaml
@@ -6,8 +6,8 @@ info:
   summary: Soccer City Stadium
   description: |
     First National Bank Stadium or simply FNB Stadium, also known as Soccer City and The Calabash, is a stadium located in Nasrec, the Soweto area of Johannesburg, South Africa.
-    Designed as the main association football stadium for the World Cup, the FNB Stadium became the largest stadium in Africa with a capacity of 94,736. 
-    
+    Designed as the main association football stadium for the World Cup, the FNB Stadium became the largest stadium in Africa with a capacity of 94,736.
+
     Statistics
     Lot size: 18 x 18
     Cost: Free

--- a/src/yaml/kergelen/parkings-on-slope.yaml
+++ b/src/yaml/kergelen/parkings-on-slope.yaml
@@ -5,14 +5,11 @@ subfolder: 700-transit
 info:
   summary: Parkings on-slope
   description: |
-    This is a set of parkings to fit on the slopes.
-    You can use on slopes between 0 to 30 meters.
+    This is a set of parking lots to fit on the slopes. You can use them on slopes between 0 to 30 meters.
 
-    You will find the Lots under the "Rail Menu".
-    The set also includes a small add-on with some plaza pieces.
+    You will find the Lots under the "Rail Menu". The set also includes a small add-on with some plaza pieces.
 
-    You can find the lots in the LotEditor under the name: KRG_1x1_RailSide_...
-    Important: In order to place correctly the lots need to be a road/rail above and below the slope as shown in the pictures!
+    Important: In order to be placed correctly the lots need to be a road/rail above and below the slope as shown in the pictures!
 
     CONTENTS
      - 1 straight parking piece with tree
@@ -37,8 +34,6 @@ dependencies:
   - bsc:mega-props-cp-vol01
   - girafe:ashes
   - bsc:mega-props-swi21-vol01
-  - bsc:mega-props-sg-vol01
-  - namspopof:props-pack-vol2
 assets:
   - assetId: kergelen-parkings-on-slope
     exclude:
@@ -67,6 +62,8 @@ info:
 
 dependencies:
   - kergelen:parkings-on-slope
+  - bsc:mega-props-sg-vol01
+  - namspopof:props-pack-vol2
 assets:
   - assetId: kergelen-parkings-on-slope
     include:

--- a/src/yaml/kergelen/parkings-on-slope.yaml
+++ b/src/yaml/kergelen/parkings-on-slope.yaml
@@ -30,10 +30,10 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_08_2013/00e53b138206443c0120fe79f884153c-parking-grid.png
 
 dependencies:
-  - mattb325:cruise-ship-terminal
+  - paeng:streetside-diagonal-parking-textures
+  - mattb325:cruise-ship-terminal-retaining-wall
   - bsc:mega-props-newmaninc-vol02
   - shk:parking-pack
-  - paeng:streetside-diagonal-parking
   - bsc:mega-props-cp-vol01
   - girafe:ashes
   - bsc:mega-props-swi21-vol01
@@ -43,13 +43,6 @@ assets:
   - assetId: kergelen-parkings-on-slope
     exclude:
       - Kergelen Parking on slope/Add-on/
-  - assetId: mattb325-cruise-ship-terminal
-    include:
-      - Mattb325 Cruise Ship Terminal/Mattb325_RetainingWall-0x5ad0e817_0x9d7c94d6_0x30000.SC4Model
-      - Mattb325 Cruise Ship Terminal/Mattb325_RetainingWall-0x6534284a-0x13a0bd51-0xbdaab9ca.SC4Desc
-  - assetId: paeng-streetside-diagonal-parking
-    include:
-      - KEEP_SSDP_Resource.dat
 
 ---
 group: kergelen

--- a/src/yaml/kingofsimcity/irm-base-fa-filler-set.yaml
+++ b/src/yaml/kingofsimcity/irm-base-fa-filler-set.yaml
@@ -3,10 +3,10 @@ name: irm-base-fa-filler-set
 version: "1.00"
 subfolder: 400-industrial
 info:
-  summary: Industrial Revolution Mod - Base FA Filler Set
-  description: |
-    This is a set of filler lots for dirty, manufacturing, and hi-tech industry geared towards adding FA (Fractional Angle) support to the originals.
-    The set was designed with IRM in mind and as such, utilizes matching bases and walls from that of T Wrecks' original release.
+  summary: Industrial Revolution Mod - Base Fractional-Angle Filler Set
+  description: >
+    This is a set of ploppable filler lots for dirty, manufacturing, and hi-tech industry geared towards adding FA (Fractional Angle) support to the originals.
+    The set was designed with IRM in mind and as such, utilizes matching bases and walls from that of T Wrecks' original release (`pkg=memo:industrial-revolution-mod`).
 
     This package contains a set of 12 wall filler lots: 4 for dirty, manufacturing and hi-tech industry respectively. FA2 (2x1) and FA3 (3x1) are supported and each type comes with a mirrored version.
     With the exception of I-HT variants - which are wall-less pieces - both I-D and I-M use the same walls as the originals.

--- a/src/yaml/kingofsimcity/irm-base-fa-filler-set.yaml
+++ b/src/yaml/kingofsimcity/irm-base-fa-filler-set.yaml
@@ -1,0 +1,37 @@
+group: kingofsimcity
+name: irm-base-fa-filler-set
+version: "1.00"
+subfolder: 400-industrial
+info:
+  summary: Industrial Revolution Mod - Base FA Filler Set
+  description: |
+    This is a set of filler lots for dirty, manufacturing, and hi-tech industry geared towards adding FA (Fractional Angle) support to the originals.
+    The set was designed with IRM in mind and as such, utilizes matching bases and walls from that of T Wrecks' original release.
+
+    This package contains a set of 12 wall filler lots: 4 for dirty, manufacturing and hi-tech industry respectively. FA2 (2x1) and FA3 (3x1) are supported and each type comes with a mirrored version.
+    With the exception of I-HT variants - which are wall-less pieces - both I-D and I-M use the same walls as the originals.
+
+    Lot stats are designed to match the original IRM fillers as closely as possible. Positioning indicators are present to help with lot placement and alignment.
+    Every lot is practically neutral, with negligible amounts of pollution, no power/water consumption and cost nothing to maintain.
+    It takes §5 to bulldoze a lot and are extremely cheap to plop (§5 for I-D, §6 for I-M, §7 for I-HT).
+
+    The lots are located in the landmarks menu and are positioned in-line with the originals.
+  author: kingofsimcity
+  website: https://community.simtropolis.com/files/file/32426-industrial-revolution-mod-base-fa-filler-set/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2018_08/splash.thumb.jpg.8f8fd9ad78d7a27a9c326b92dd2a402c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2018_08/detail_1.thumb.jpg.53bcd017787d8a8da7d6a41b234879e9.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2018_08/lots.thumb.jpg.b80338c5684b272bd4bf04e5376ce408.jpg
+
+dependencies:
+  - bsc:mega-props-cp-vol01
+  - sfbt:essentials
+  - ncd:rail-yard-and-spur-mega-pak-1
+assets:
+  - assetId: kingofsimcity-irm-base-fa-filler-set
+
+---
+assetId: kingofsimcity-irm-base-fa-filler-set
+version: "1.00"
+lastModified: "2018-08-20T05:54:31Z"
+url: https://community.simtropolis.com/files/file/32426-industrial-revolution-mod-base-fa-filler-set/?do=download

--- a/src/yaml/kingofsimcity/irm-big-logistic-filler-set.yaml
+++ b/src/yaml/kingofsimcity/irm-big-logistic-filler-set.yaml
@@ -26,6 +26,8 @@ info:
 dependencies:
   - kingofsimcity:logistics-essentials
   - shk:parking-pack
+  - mushymushy:na-40ft-trailers-vol1
+  - mushymushy:na-53ft-trailers-vol1
   - supershk:mega-parking-textures
   - supershk:fa3-parking-textures
   - bsc:mega-props-sg-vol01

--- a/src/yaml/kingofsimcity/irm-big-logistic-filler-set.yaml
+++ b/src/yaml/kingofsimcity/irm-big-logistic-filler-set.yaml
@@ -1,0 +1,43 @@
+group: kingofsimcity
+name: irm-big-logistic-filler-set
+version: "1.00"
+subfolder: 400-industrial
+info:
+  summary: Industrial Revolution Mod - Big Logistic Filler Set
+  description: |
+    This is a set of larger, prefab filler lots for dirty, manufacturing, and hi-tech industry which seek to expand logistic support for your industries.
+    The set was designed with IRM in mind and as such, utilizes matching bases and walls from that of T Wrecks' original release.
+
+    This package contains a set of 15 large prefab lots: 5 for dirty, manufacturing and hi-tech industry respectively. There are 3 dedicated transit-enabled entrances.
+    The rest of the lots are dedicated to large blocks of parked semis and trailers, with 45 degree parking for semi trucks and 22.5 degree parking for trailers only.
+    All of the lots are also available in a mirrored configuration.
+    Lot stats are designed to match the original IRM fillers as closely as possible.
+
+    Positioning indicators are present to help with lot placement and alignment. Every lot is practically neutral, with negligible amounts of pollution, no power/water consumption and cost nothing to maintain.
+    It takes §5 to bulldoze a lot and they are also extremely cheap to plop. Due to the lots being of considerable size, the plop costs have been doubled respectively (§10 for I-D, §12 for I-M, §14 for I-HT).
+    The lots are located in the landmarks menu and are positioned just after the originals.
+  author: kingofsimcity
+  website: https://community.simtropolis.com/files/file/32413-industrial-revolution-mod-big-logistic-filler-set/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2018_08/splash.thumb.jpg.b63b13606d54fc242ec7035896fe72c5.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2018_08/detail_1.thumb.jpg.e5f6df71d721007c5b166b6d90d541d9.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2018_08/lots.thumb.jpg.2687cc2db242c7e6440e1c7f0cc6d682.jpg
+
+dependencies:
+  - kingofsimcity:logistics-essentials
+  - shk:parking-pack
+  - supershk:mega-parking-textures
+  - supershk:fa3-parking-textures
+  - bsc:mega-props-sg-vol01
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-jes-vol02
+  - sfbt:essentials
+  - ncd:rail-yard-and-spur-mega-pak-1
+assets:
+  - assetId: kingofsimcity-irm-big-logistic-filler-set
+
+---
+assetId: kingofsimcity-irm-big-logistic-filler-set
+version: "1.00"
+lastModified: "2018-08-15T03:08:18Z"
+url: https://community.simtropolis.com/files/file/32413-industrial-revolution-mod-big-logistic-filler-set/?do=download

--- a/src/yaml/kingofsimcity/irm-big-logistic-filler-set.yaml
+++ b/src/yaml/kingofsimcity/irm-big-logistic-filler-set.yaml
@@ -4,9 +4,9 @@ version: "1.00"
 subfolder: 400-industrial
 info:
   summary: Industrial Revolution Mod - Big Logistic Filler Set
-  description: |
-    This is a set of larger, prefab filler lots for dirty, manufacturing, and hi-tech industry which seek to expand logistic support for your industries.
-    The set was designed with IRM in mind and as such, utilizes matching bases and walls from that of T Wrecks' original release.
+  description: >
+    This is a set of larger, ploppable prefab filler lots for dirty, manufacturing, and hi-tech industry which seek to expand logistic support for your industries.
+    The set was designed with IRM in mind and as such, utilizes matching bases and walls from that of T Wrecks' original release (`pkg=memo:industrial-revolution-mod`).
 
     This package contains a set of 15 large prefab lots: 5 for dirty, manufacturing and hi-tech industry respectively. There are 3 dedicated transit-enabled entrances.
     The rest of the lots are dedicated to large blocks of parked semis and trailers, with 45 degree parking for semi trucks and 22.5 degree parking for trailers only.

--- a/src/yaml/kingofsimcity/irm-logistic-filler-set-1.yaml
+++ b/src/yaml/kingofsimcity/irm-logistic-filler-set-1.yaml
@@ -1,0 +1,45 @@
+group: kingofsimcity
+name: irm-logistic-filler-set-1
+version: "1.00"
+subfolder: 400-industrial
+info:
+  summary: Industrial Revolution Mod - Logistic Filler Set 1
+  description: |
+    This is a set of ploppable filler lots for dirty, manufacturing, and hi-tech industry which are designed to add some logistic support to your industrial areas.
+    The set was designed with IRM in mind and as such, utilizes matching bases and walls from that of the original releases.
+
+    This package contains a set of 15 filler lots: 5 for dirty, manufacturing and hi-tech industrial areas.
+    All the lots have props that are highly randomized.
+    Parked trailers and semi cabs will show up in many different sizes and forms and sometimes not even at all.
+
+    Lot stats are designed to match the original IRM fillers as closely as possible.
+    This includes positioning indicators to help you align the lots with respect to other things around it.
+    Every lot is nearly neutral, with negligible amounts of pollution, no power/water consumption and are maintenance free.
+    All lots are $5 to bulldoze and are extremely cheap to plop ($5 for I-D, $6 for I-M, $7 for I-HT).
+
+    The lots are located in the landmarks menu and clumped together with the original filler sets.
+  author: kingofsimcity
+  website: https://community.simtropolis.com/files/file/31590-industrial-revolution-mod-logistic-filler-set-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2017_04/splash.thumb.jpg.62d2e57d59dbb42b848f63f2d969e5ab.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_04/tiles.thumb.jpg.16d316d3c0e8bc6d377c131cf354dd0d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_04/detail_1.thumb.jpg.f262a450594bbd3341732d0d9dc3c26c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_04/detail_2.thumb.jpg.fc07a2e45b9ae21f51e30b4c73638491.jpg
+
+dependencies:
+  - kingofsimcity:logistics-essentials
+  - bsc:mega-props-misc-vol01
+  - bsc:mega-props-sg-vol01
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-jes-vol01
+  - bsc:mega-props-jes-vol02
+  - sfbt:essentials
+  - ncd:rail-yard-and-spur-mega-pak-1
+assets:
+  - assetId: kingofsimcity-irm-logistic-filler-set-1
+
+---
+assetId: kingofsimcity-irm-logistic-filler-set-1
+version: "1.00"
+lastModified: "2017-04-27T02:23:36Z"
+url: https://community.simtropolis.com/files/file/31590-industrial-revolution-mod-logistic-filler-set-1/?do=download

--- a/src/yaml/kingofsimcity/irm-logistic-filler-set-1.yaml
+++ b/src/yaml/kingofsimcity/irm-logistic-filler-set-1.yaml
@@ -28,7 +28,10 @@ info:
 
 dependencies:
   - kingofsimcity:logistics-essentials
-  - bsc:mega-props-misc-vol01
+  - mushymushy:na-semi-truck-cabs-vol1
+  - mushymushy:na-40ft-trailers-vol1
+  - mushymushy:na-53ft-trailers-vol1
+  - bsc:mega-props-misc-vol02
   - bsc:mega-props-sg-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-jes-vol01

--- a/src/yaml/kingofsimcity/irm-logistic-filler-set-1.yaml
+++ b/src/yaml/kingofsimcity/irm-logistic-filler-set-1.yaml
@@ -6,7 +6,7 @@ info:
   summary: Industrial Revolution Mod - Logistic Filler Set 1
   description: |
     This is a set of ploppable filler lots for dirty, manufacturing, and hi-tech industry which are designed to add some logistic support to your industrial areas.
-    The set was designed with IRM in mind and as such, utilizes matching bases and walls from that of the original releases.
+    The set was designed with IRM in mind and as such, utilizes matching bases and walls from that of the original releases (`pkg=memo:industrial-revolution-mod`).
 
     This package contains a set of 15 filler lots: 5 for dirty, manufacturing and hi-tech industrial areas.
     All the lots have props that are highly randomized.

--- a/src/yaml/kingofsimcity/irm-logistic-filler-set-2.yaml
+++ b/src/yaml/kingofsimcity/irm-logistic-filler-set-2.yaml
@@ -4,13 +4,13 @@ version: "1.00"
 subfolder: 400-industrial
 info:
   summary: Industrial Revolution Mod - Logistic Filler Set 2
-  description: |
-    This package contains a set of 12 filler lots: 4 for dirty, manufacturing and hi-tech industrial areas.
+  description: >
+    This package contains a set of 12 ploppable filler lots: 4 for dirty, manufacturing and hi-tech industrial areas.
     Each industrial type has 2 common lot types and 2 unique ones.
     Unique lots include dump trucks and oil tankers for I-D, flatbeds with piping and random junk for I-M, and temp offices and flatbeds with objects covered in tarp for I-HT. Like previous releases, all lots are configured to be highly randomized.
     Do note that most of the lots here are wider (2x2).
 
-    Lot stats are designed to match the original IRM fillers as closely as possible.
+    Lot stats are designed to match the original IRM fillers as closely as possible (`pkg=memo:industrial-revolution-mod`).
     Positioning indicators are present to help with lot placement and alignment.
     Every lot is practically neutral, with negligible amounts of pollution, no power/water consumption and cost nothing to maintain.
     It takes §5 to bulldoze a lot and each are extremely cheap to plop (§5 for I-D, §6 for I-M, §7 for I-HT).

--- a/src/yaml/kingofsimcity/irm-logistic-filler-set-2.yaml
+++ b/src/yaml/kingofsimcity/irm-logistic-filler-set-2.yaml
@@ -11,10 +11,10 @@ info:
     Do note that most of the lots here are wider (2x2).
 
     Lot stats are designed to match the original IRM fillers as closely as possible.
-    Positioning indicators are present to help with lot placement and alignment. 
+    Positioning indicators are present to help with lot placement and alignment.
     Every lot is practically neutral, with negligible amounts of pollution, no power/water consumption and cost nothing to maintain.
     It takes §5 to bulldoze a lot and each are extremely cheap to plop (§5 for I-D, §6 for I-M, §7 for I-HT).
-    
+
     The lots are located in the landmarks menu and are positioned in-line with the originals.
   author: kingofsimcity
   website: https://community.simtropolis.com/files/file/32758-industrial-revolution-mod-logistic-filler-set-2/

--- a/src/yaml/kingofsimcity/irm-logistic-filler-set-2.yaml
+++ b/src/yaml/kingofsimcity/irm-logistic-filler-set-2.yaml
@@ -1,0 +1,42 @@
+group: kingofsimcity
+name: irm-logistic-filler-set-2
+version: "1.00"
+subfolder: 400-industrial
+info:
+  summary: Industrial Revolution Mod - Logistic Filler Set 2
+  description: |
+    This package contains a set of 12 filler lots: 4 for dirty, manufacturing and hi-tech industrial areas.
+    Each industrial type has 2 common lot types and 2 unique ones.
+    Unique lots include dump trucks and oil tankers for I-D, flatbeds with piping and random junk for I-M, and temp offices and flatbeds with objects covered in tarp for I-HT. Like previous releases, all lots are configured to be highly randomized.
+    Do note that most of the lots here are wider (2x2).
+
+    Lot stats are designed to match the original IRM fillers as closely as possible.
+    Positioning indicators are present to help with lot placement and alignment. 
+    Every lot is practically neutral, with negligible amounts of pollution, no power/water consumption and cost nothing to maintain.
+    It takes §5 to bulldoze a lot and each are extremely cheap to plop (§5 for I-D, §6 for I-M, §7 for I-HT).
+    
+    The lots are located in the landmarks menu and are positioned in-line with the originals.
+  author: kingofsimcity
+  website: https://community.simtropolis.com/files/file/32758-industrial-revolution-mod-logistic-filler-set-2/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_02/splash.thumb.jpg.8f3747669d58105f1bf9b4206153ee76.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_02/details.thumb.jpg.e01517d0e959fb154cb9aada832eb81d.jpg
+
+dependencies:
+  - kingofsimcity:logistics-essentials
+  - angry-mozart:trucks-and-trailers-props
+  - shk:parking-pack
+  - bsc:mega-props-sg-vol01
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-jes-vol01
+  - bsc:mega-props-jes-vol02
+  - sfbt:essentials
+  - ncd:rail-yard-and-spur-mega-pak-1
+assets:
+  - assetId: kingofsimcity-irm-logistic-filler-set-2
+
+---
+assetId: kingofsimcity-irm-logistic-filler-set-2
+version: "1.00"
+lastModified: "2019-02-19T04:58:31Z"
+url: https://community.simtropolis.com/files/file/32758-industrial-revolution-mod-logistic-filler-set-2/?do=download

--- a/src/yaml/kingofsimcity/sp-modular-parking-add-on-pack-1.yaml
+++ b/src/yaml/kingofsimcity/sp-modular-parking-add-on-pack-1.yaml
@@ -5,7 +5,7 @@ subfolder: 700-transit
 info:
   summary: SP Modular Parking - Add-on Pack 1
   description: |
-    This is the 1st addon pack of my SuperParking modular parking series. Unlike a full-blown expansion, this small pack covers some odds and ends that I missed on the original sets. These include full no road marking support for all junction variations, and a couple of transitions for a few awkward spots.Package Overview
+    This is the 1st addon pack of the SuperParking modular parking series. Unlike a full-blown expansion, this small pack covers some odds and ends that I missed on the original sets. These include full no road marking support for all junction variations, and a couple of transitions for a few awkward spots.Package Overview
 
     The set contains a set of 14 lots, all of which are cosmetic pieces located near the top of the Parks menu. Like before all of the menus are grouped and color coded according to the specific type of parking. DAMN menu support for this addon pack is included in the integrated package here.
 

--- a/src/yaml/kingofsimcity/sp-modular-parking-add-on-pack-1.yaml
+++ b/src/yaml/kingofsimcity/sp-modular-parking-add-on-pack-1.yaml
@@ -5,9 +5,9 @@ subfolder: 700-transit
 info:
   summary: SP Modular Parking - Add-on Pack 1
   description: |
-    This is the 1st addon pack of the SuperParking modular parking series. Unlike a full-blown expansion, this small pack covers some odds and ends that I missed on the original sets. These include full no road marking support for all junction variations, and a couple of transitions for a few awkward spots.Package Overview
+    This is the 1st addon pack of the SuperParking modular parking series. Unlike a full-blown expansion, this small pack covers some odds and ends that were missed on the original sets. These include full no road marking support for all junction variations, and a couple of transitions for a few awkward spots.
 
-    The set contains a set of 14 lots, all of which are cosmetic pieces located near the top of the Parks menu. Like before all of the menus are grouped and color coded according to the specific type of parking. DAMN menu support for this addon pack is included in the integrated package here.
+    The set contains a set of 14 lots, all of which are cosmetic pieces located near the top of the Parks menu. Like before all of the menus are grouped and color coded according to the specific type of parking.
 
     General Stats
       - Cosmetic Pieces

--- a/src/yaml/kingofsimcity/sp-modular-parking-base-set.yaml
+++ b/src/yaml/kingofsimcity/sp-modular-parking-base-set.yaml
@@ -10,7 +10,7 @@ info:
     There are two different packages available for download: one for Right-hand Drive and Left-hand Drive. Choose one.
 
     The set contains a set of 49 lots. There are 7 functional “parking garage” pieces, with Transit Enabled connections which are located in the Misc Transportation menu, and 42 cosmetic pieces located near the top of the Parks menu. All of the menus are grouped and color coded according to the specific type of parking, ranging from A to D type.
-    
+
     General Stats
       - Street Entrances
         - Plop Cost: $250

--- a/src/yaml/kingofsimcity/sp-modular-parking-base-set.yaml
+++ b/src/yaml/kingofsimcity/sp-modular-parking-base-set.yaml
@@ -5,9 +5,7 @@ subfolder: 700-transit
 info:
   summary: SP Modular Parking - Base Set
   description: |
-
     This is the 1st part of the SuperParking modular parking series, which is aimed towards creating even more realistic and crazy parking derivatives from the original SHK Parking Pack. This is the base set, which contains all the essentials for making orthogonal oriented parking lots, junctions, and more.
-    There are two different packages available for download: one for Right-hand Drive and Left-hand Drive. Choose one.
 
     The set contains a set of 49 lots. There are 7 functional “parking garage” pieces, with Transit Enabled connections which are located in the Misc Transportation menu, and 42 cosmetic pieces located near the top of the Parks menu. All of the menus are grouped and color coded according to the specific type of parking, ranging from A to D type.
 

--- a/src/yaml/kingofsimcity/sp-modular-parking-base-set.yaml
+++ b/src/yaml/kingofsimcity/sp-modular-parking-base-set.yaml
@@ -6,7 +6,7 @@ info:
   summary: SP Modular Parking - Base Set
   description: |
 
-    This is the 1st part of my SuperParking modular parking series, which is aimed towards creating even more realistic and crazy parking derivatives from the original SHK Parking Pack. This is the base set, which contains all the essentials for making orthogonal oriented parking lots, junctions, and more.
+    This is the 1st part of the SuperParking modular parking series, which is aimed towards creating even more realistic and crazy parking derivatives from the original SHK Parking Pack. This is the base set, which contains all the essentials for making orthogonal oriented parking lots, junctions, and more.
     There are two different packages available for download: one for Right-hand Drive and Left-hand Drive. Choose one.
 
     The set contains a set of 49 lots. There are 7 functional “parking garage” pieces, with Transit Enabled connections which are located in the Misc Transportation menu, and 42 cosmetic pieces located near the top of the Parks menu. All of the menus are grouped and color coded according to the specific type of parking, ranging from A to D type.

--- a/src/yaml/kingofsimcity/sp-modular-parking-diagonal-set.yaml
+++ b/src/yaml/kingofsimcity/sp-modular-parking-diagonal-set.yaml
@@ -6,7 +6,7 @@ info:
   summary: SP Modular Parking - Diagonal Set
   description: |
 
-    This is the 1st expansion pack of my SuperParking modular parking series, which is aimed towards creating even more realistic and crazy parking derivatives from the original SHK Parking Pack. This set covers diagonals - largely uncharted territory - by adding a plethora of new parking options for your cities including the ability to create fully-diagonal oriented parking lots. As if that wasn't enough, there's a wealth of different orthogonal transitions and connector pieces to combine with the base set for even more ridiculous combinations.
+    This is the 1st expansion pack of the SuperParking modular parking series, which is aimed towards creating even more realistic and crazy parking derivatives from the original SHK Parking Pack. This set covers diagonals - largely uncharted territory - by adding a plethora of new parking options for your cities including the ability to create fully-diagonal oriented parking lots. As if that wasn't enough, there's a wealth of different orthogonal transitions and connector pieces to combine with the base set for even more ridiculous combinations.
 
     The set contains a set of 50 lots. There are 3 functional “parking garage” pieces, with Transit Enabled connections which are located in the Misc Transportation menu, and 47 cosmetic pieces located near the top of the Parks menu. All of the menus are grouped and color coded according to the specific type of parking, including A, B, and Joiner categories.
 

--- a/src/yaml/kingofsimcity/sp-modular-parking-diagonal-set.yaml
+++ b/src/yaml/kingofsimcity/sp-modular-parking-diagonal-set.yaml
@@ -5,7 +5,6 @@ subfolder: 700-transit
 info:
   summary: SP Modular Parking - Diagonal Set
   description: |
-
     This is the 1st expansion pack of the SuperParking modular parking series, which is aimed towards creating even more realistic and crazy parking derivatives from the original SHK Parking Pack. This set covers diagonals - largely uncharted territory - by adding a plethora of new parking options for your cities including the ability to create fully-diagonal oriented parking lots. As if that wasn't enough, there's a wealth of different orthogonal transitions and connector pieces to combine with the base set for even more ridiculous combinations.
 
     The set contains a set of 50 lots. There are 3 functional “parking garage” pieces, with Transit Enabled connections which are located in the Misc Transportation menu, and 47 cosmetic pieces located near the top of the Parks menu. All of the menus are grouped and color coded according to the specific type of parking, including A, B, and Joiner categories.

--- a/src/yaml/kingofsimcity/sp-modular-parking-extension-set.yaml
+++ b/src/yaml/kingofsimcity/sp-modular-parking-extension-set.yaml
@@ -6,9 +6,9 @@ info:
   summary: SP Modular Parking - Extension Set
   description: |
     This is the 2nd expansion pack of the SuperParking modular parking series, which unlocks even more ridiculous combinations for your parking lots. This set adds some much needed larger basic pieces and covers advanced pathing, S-curves, and more.
-    
+
     The set contains a set of 44 lots. There are 2 functional “parking garage” pieces, with Transit Enabled connections which are located in the Misc Transportation menu, and 42 cosmetic pieces located near the top of the Parks menu. All of the menus are grouped and color coded according to the specific type of parking, ranging from A to D type. These are broken down in the included readme, which also includes a couple of useful tips for some of the more complex combinations.
-    
+
     General Stats
       - Street Entrance
         - Plop Cost: $250

--- a/src/yaml/kingofsimcity/sp-modular-parking-extension-set.yaml
+++ b/src/yaml/kingofsimcity/sp-modular-parking-extension-set.yaml
@@ -5,7 +5,7 @@ subfolder: 700-transit
 info:
   summary: SP Modular Parking - Extension Set
   description: |
-    This is the 2nd expansion pack of my SuperParking modular parking series, which unlocks even more ridiculous combinations for your parking lots. This set adds some much needed larger basic pieces and covers advanced pathing, S-curves, and more.
+    This is the 2nd expansion pack of the SuperParking modular parking series, which unlocks even more ridiculous combinations for your parking lots. This set adds some much needed larger basic pieces and covers advanced pathing, S-curves, and more.
     
     The set contains a set of 44 lots. There are 2 functional “parking garage” pieces, with Transit Enabled connections which are located in the Misc Transportation menu, and 42 cosmetic pieces located near the top of the Parks menu. All of the menus are grouped and color coded according to the specific type of parking, ranging from A to D type. These are broken down in the included readme, which also includes a couple of useful tips for some of the more complex combinations.
     

--- a/src/yaml/mattb325/cruise-ship-terminal.yaml
+++ b/src/yaml/mattb325/cruise-ship-terminal.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 subfolder: 700-transit
 info:
   summary: Cruise Ship Terminal
-  description: |
+  description: >
     Using the cruise ship terminal helps to break through demand caps, increase mayor and landmark ratings, and provides jobs; all of these enable you to get a thriving high end commercial services sector and enable a higher populations of R$$ and R$$$ sims.
     This is crucial to helping build large cities.
 
@@ -16,19 +16,6 @@ info:
     Unlike the ingame version, it does not require certain thresholds to be met before being unlocked, and it can also be placed more than once in the same city.
     It does NOT replace the Maxis version and you can have both co-exist in the same city if you wish.
     The lot size is a more realistic and substantial 7 tiles wide by 5 tiles deep.
-
-    Stats:
-      - Plop cost: $28,000
-      - Maintenance Cost: $180
-      - Bulldoze Cost: $269
-      - R$$ Jobs: 45
-      - Demand created: 45
-      - Pollution: 1 (air) 1 (water) 11 (garbage)
-      - Radii: 2/4/1 tiles
-      - Landmark Effect: 60 over 24 tiles
-      - Mayor Rating: 10 over 256 tiles
-      - Water consumed: 75 Gallons
-      - Power Consumed: 50MwH
   author: mattb325
   website: https://community.simtropolis.com/files/file/27915-cruise-ship-terminal/
   images:

--- a/src/yaml/mattb325/cruise-ship-terminal.yaml
+++ b/src/yaml/mattb325/cruise-ship-terminal.yaml
@@ -5,12 +5,11 @@ subfolder: 700-transit
 info:
   summary: Cruise Ship Terminal
   description: |
-    The in game cruise ship building has always been a disappointment, and while a few folk have attempted to re-lot the original, I am unaware of anything that has ever been released that complements (rather than over-writes) the function of the cruise ship building.
     Using the cruise ship terminal helps to break through demand caps, increase mayor and landmark ratings, and provides jobs; all of these enable you to get a thriving high end commercial services sector and enable a higher populations of R$$ and R$$$ sims.
     This is crucial to helping build large cities.
 
     In real life, most cruise ship terminals are fairly swank affairs as, just like airports, they are often the first impression a visitor has of a city.
-    This cruise ship building that I have made is modded similarly to the in-game version and I have also made custom seawalls for the lot.
+    This cruise ship building is modded similarly to the in-game version and there are also custom made seawalls for the lot.
     Like the ingame version, it is found in the rewards menu and provides jobs once plopped.
     It therefore needs road access.
 

--- a/src/yaml/mattb325/cruise-ship-terminal.yaml
+++ b/src/yaml/mattb325/cruise-ship-terminal.yaml
@@ -42,8 +42,29 @@ dependencies:
   - bsc:textures-vol01
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03
+  - mattb325:cruise-ship-terminal-retaining-wall
+
 assets:
   - assetId: mattb325-cruise-ship-terminal
+    exclude:
+      - Mattb325 Cruise Ship Terminal/Mattb325_RetainingWall-0x5ad0e817_0x9d7c94d6_0x30000.SC4Model
+      - Mattb325 Cruise Ship Terminal/Mattb325_RetainingWall-0x6534284a-0x13a0bd51-0xbdaab9ca.SC4Desc
+
+---
+group: mattb325
+name: cruise-ship-terminal-retaining-wall
+version: "1.0"
+subfolder: 100-props-textures
+info:
+  summary: Retaining Wall prop
+  author: mattb325
+  website: https://community.simtropolis.com/files/file/27915-cruise-ship-terminal/
+
+assets:
+  - assetId: mattb325-cruise-ship-terminal
+    include:
+      - Mattb325 Cruise Ship Terminal/Mattb325_RetainingWall-0x5ad0e817_0x9d7c94d6_0x30000.SC4Model
+      - Mattb325 Cruise Ship Terminal/Mattb325_RetainingWall-0x6534284a-0x13a0bd51-0xbdaab9ca.SC4Desc
 
 ---
 assetId: mattb325-cruise-ship-terminal

--- a/src/yaml/mayorbean/ocean-river-mod.yaml
+++ b/src/yaml/mayorbean/ocean-river-mod.yaml
@@ -1,0 +1,241 @@
+group: "mayorbean"
+name: "ocean-river-mod"
+version: "1.1"
+subfolder: "150-mods"
+info:
+  summary: Ocean River Mod
+  description: |
+    Replaces the ingame water textures. The watercolor will differ depending on depth and viewing angle. It looks best at a waterdepth between 0m and 30m.
+  author: "mayorbean"
+  images:
+    - https://www.simtropolis.com/objects/screens/0002/0becdafa3a030cad2381f492fc4e04c0-__MBCC-ORM-1.1final-UpdateFiles.jpg
+    - https://www.simtropolis.com/objects/screens/0002/0becdafa3a030cad2381f492fc4e04c0-OceanRiverSet1.jpg
+  website: https://community.simtropolis.com/files/file/11628-ocean-river-mod-final/
+
+assets:
+  - assetId: "mayorbean-ocean-river-mod"
+    include:
+      - OceanRiverMod/TerrainProperties.dat
+      - OceanRiverMod/WaterSurface_256.dat
+
+variantDescriptions:
+  mayorbean:ocean-river-mod:shallow:
+    5f5f00: "dark moss green shallow water"
+    "669966": "asparagus shallow water"
+    "669999": "blue shallow water"
+    "grass": "grass textured shallow water"
+    "marsh": "marsh textured shallow water"
+  mayorbean:ocean-river-mod:deep:
+    5f5f00: "dark moss green deep water"
+    "669966": "asparagus deep water"
+    "669999": "blue deep water"
+    "grass": "grass textured deep water"
+    "marsh": "marsh textured deep water"
+
+variants:
+  - variant:
+      mayorbean:ocean-river-mod:shallow: 5f5f00
+      mayorbean:ocean-river-mod:deep: 5f5f00
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_5F5F00.dat
+          - OceanRiverMod/DeepSea_5F5F00.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: 5f5f00
+      mayorbean:ocean-river-mod:deep: "669966"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_5F5F00.dat
+          - OceanRiverMod/DeepSea_669966.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: 5f5f00
+      mayorbean:ocean-river-mod:deep: "669999"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_5F5F00.dat
+          - OceanRiverMod/DeepSea_669999.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: 5f5f00
+      mayorbean:ocean-river-mod:deep: "grass"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_5F5F00.dat
+          - OceanRiverMod/DeepSea_Grass.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: 5f5f00
+      mayorbean:ocean-river-mod:deep: "marsh"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_5F5F00.dat
+          - OceanRiverMod/DeepSea_Marsh.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "669966"
+      mayorbean:ocean-river-mod:deep: 5f5f00
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_669966.dat
+          - OceanRiverMod/DeepSea_5F5F00.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "669966"
+      mayorbean:ocean-river-mod:deep: "669966"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_669966.dat
+          - OceanRiverMod/DeepSea_669966.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "669966"
+      mayorbean:ocean-river-mod:deep: "669999"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_669966.dat
+          - OceanRiverMod/DeepSea_669999.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "669966"
+      mayorbean:ocean-river-mod:deep: "grass"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_669966.dat
+          - OceanRiverMod/DeepSea_Grass.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "669966"
+      mayorbean:ocean-river-mod:deep: "marsh"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_669966.dat
+          - OceanRiverMod/DeepSea_Marsh.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "669999"
+      mayorbean:ocean-river-mod:deep: 5f5f00
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_669999.dat
+          - OceanRiverMod/DeepSea_5F5F00.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "669999"
+      mayorbean:ocean-river-mod:deep: "669966"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_669999.dat
+          - OceanRiverMod/DeepSea_669966.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "669999"
+      mayorbean:ocean-river-mod:deep: "669999"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_669999.dat
+          - OceanRiverMod/DeepSea_669999.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "669999"
+      mayorbean:ocean-river-mod:deep: "grass"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_669999.dat
+          - OceanRiverMod/DeepSea_Grass.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "669999"
+      mayorbean:ocean-river-mod:deep: "marsh"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_669999.dat
+          - OceanRiverMod/DeepSea_Marsh.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "grass"
+      mayorbean:ocean-river-mod:deep: 5f5f00
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_Grass.dat
+          - OceanRiverMod/DeepSea_5F5F00.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "grass"
+      mayorbean:ocean-river-mod:deep: "669966"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_Grass.dat
+          - OceanRiverMod/DeepSea_669966.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "grass"
+      mayorbean:ocean-river-mod:deep: "669999"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_Grass.dat
+          - OceanRiverMod/DeepSea_669999.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "grass"
+      mayorbean:ocean-river-mod:deep: "grass"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_Grass.dat
+          - OceanRiverMod/DeepSea_Grass.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "grass"
+      mayorbean:ocean-river-mod:deep: "marsh"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_Grass.dat
+          - OceanRiverMod/DeepSea_Marsh.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "marsh"
+      mayorbean:ocean-river-mod:deep: 5f5f00
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_Marsh.dat
+          - OceanRiverMod/DeepSea_5F5F00.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "marsh"
+      mayorbean:ocean-river-mod:deep: "669966"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_Marsh.dat
+          - OceanRiverMod/DeepSea_669966.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "marsh"
+      mayorbean:ocean-river-mod:deep: "669999"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_Marsh.dat
+          - OceanRiverMod/DeepSea_669999.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "marsh"
+      mayorbean:ocean-river-mod:deep: "grass"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_Marsh.dat
+          - OceanRiverMod/DeepSea_Grass.dat
+  - variant:
+      mayorbean:ocean-river-mod:shallow: "marsh"
+      mayorbean:ocean-river-mod:deep: "marsh"
+    assets:
+      - assetId: "mayorbean-ocean-river-mod"
+        include:
+          - OceanRiverMod/ShallowWater_Marsh.dat
+          - OceanRiverMod/DeepSea_Marsh.dat
+
+---
+url: https://community.simtropolis.com/files/file/11628-ocean-river-mod-final/?do=download
+assetId: "mayorbean-ocean-river-mod"
+version: "1.1"
+lastModified: "2005-02-06T16:15:20Z"

--- a/src/yaml/mayorbean/ocean-river-mod.yaml
+++ b/src/yaml/mayorbean/ocean-river-mod.yaml
@@ -22,45 +22,45 @@ assets:
 
 variantDescriptions:
   mayorbean:ocean-river-mod:shallow:
-    5f5f00: "dark moss green shallow water"
-    "669966": "asparagus shallow water"
-    "669999": "blue shallow water"
-    "grass": "grass textured shallow water"
-    "marsh": "marsh textured shallow water"
+    moss-green: "dark moss green shallow water"
+    asparagus: "asparagus shallow water"
+    blue: "blue shallow water"
+    grass: "grass textured shallow water"
+    marsh: "marsh textured shallow water"
   mayorbean:ocean-river-mod:deep:
-    5f5f00: "dark moss green deep water"
-    "669966": "asparagus deep water"
-    "669999": "blue deep water"
-    "grass": "grass textured deep water"
-    "marsh": "marsh textured deep water"
+    moss-green: "dark moss green deep water"
+    asparagus: "asparagus deep water"
+    blue: "blue deep water"
+    grass: "grass textured deep water"
+    marsh: "marsh textured deep water"
 
 variants:
   - variant:
-      mayorbean:ocean-river-mod:shallow: 5f5f00
-      mayorbean:ocean-river-mod:deep: 5f5f00
+      mayorbean:ocean-river-mod:shallow: moss-green
+      mayorbean:ocean-river-mod:deep: moss-green
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
           - OceanRiverMod/ShallowWater_5F5F00.dat
           - OceanRiverMod/DeepSea_5F5F00.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: 5f5f00
-      mayorbean:ocean-river-mod:deep: "669966"
+      mayorbean:ocean-river-mod:shallow: moss-green
+      mayorbean:ocean-river-mod:deep: asparagus
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
           - OceanRiverMod/ShallowWater_5F5F00.dat
           - OceanRiverMod/DeepSea_669966.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: 5f5f00
-      mayorbean:ocean-river-mod:deep: "669999"
+      mayorbean:ocean-river-mod:shallow: moss-green
+      mayorbean:ocean-river-mod:deep: blue
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
           - OceanRiverMod/ShallowWater_5F5F00.dat
           - OceanRiverMod/DeepSea_669999.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: 5f5f00
+      mayorbean:ocean-river-mod:shallow: moss-green
       mayorbean:ocean-river-mod:deep: "grass"
     assets:
       - assetId: "mayorbean-ocean-river-mod"
@@ -68,7 +68,7 @@ variants:
           - OceanRiverMod/ShallowWater_5F5F00.dat
           - OceanRiverMod/DeepSea_Grass.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: 5f5f00
+      mayorbean:ocean-river-mod:shallow: moss-green
       mayorbean:ocean-river-mod:deep: "marsh"
     assets:
       - assetId: "mayorbean-ocean-river-mod"
@@ -76,31 +76,31 @@ variants:
           - OceanRiverMod/ShallowWater_5F5F00.dat
           - OceanRiverMod/DeepSea_Marsh.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: "669966"
-      mayorbean:ocean-river-mod:deep: 5f5f00
+      mayorbean:ocean-river-mod:shallow: asparagus
+      mayorbean:ocean-river-mod:deep: moss-green
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
           - OceanRiverMod/ShallowWater_669966.dat
           - OceanRiverMod/DeepSea_5F5F00.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: "669966"
-      mayorbean:ocean-river-mod:deep: "669966"
+      mayorbean:ocean-river-mod:shallow: asparagus
+      mayorbean:ocean-river-mod:deep: asparagus
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
           - OceanRiverMod/ShallowWater_669966.dat
           - OceanRiverMod/DeepSea_669966.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: "669966"
-      mayorbean:ocean-river-mod:deep: "669999"
+      mayorbean:ocean-river-mod:shallow: asparagus
+      mayorbean:ocean-river-mod:deep: blue
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
           - OceanRiverMod/ShallowWater_669966.dat
           - OceanRiverMod/DeepSea_669999.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: "669966"
+      mayorbean:ocean-river-mod:shallow: asparagus
       mayorbean:ocean-river-mod:deep: "grass"
     assets:
       - assetId: "mayorbean-ocean-river-mod"
@@ -108,7 +108,7 @@ variants:
           - OceanRiverMod/ShallowWater_669966.dat
           - OceanRiverMod/DeepSea_Grass.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: "669966"
+      mayorbean:ocean-river-mod:shallow: asparagus
       mayorbean:ocean-river-mod:deep: "marsh"
     assets:
       - assetId: "mayorbean-ocean-river-mod"
@@ -116,31 +116,31 @@ variants:
           - OceanRiverMod/ShallowWater_669966.dat
           - OceanRiverMod/DeepSea_Marsh.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: "669999"
-      mayorbean:ocean-river-mod:deep: 5f5f00
+      mayorbean:ocean-river-mod:shallow: blue
+      mayorbean:ocean-river-mod:deep: moss-green
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
           - OceanRiverMod/ShallowWater_669999.dat
           - OceanRiverMod/DeepSea_5F5F00.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: "669999"
-      mayorbean:ocean-river-mod:deep: "669966"
+      mayorbean:ocean-river-mod:shallow: blue
+      mayorbean:ocean-river-mod:deep: asparagus
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
           - OceanRiverMod/ShallowWater_669999.dat
           - OceanRiverMod/DeepSea_669966.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: "669999"
-      mayorbean:ocean-river-mod:deep: "669999"
+      mayorbean:ocean-river-mod:shallow: blue
+      mayorbean:ocean-river-mod:deep: blue
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
           - OceanRiverMod/ShallowWater_669999.dat
           - OceanRiverMod/DeepSea_669999.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: "669999"
+      mayorbean:ocean-river-mod:shallow: blue
       mayorbean:ocean-river-mod:deep: "grass"
     assets:
       - assetId: "mayorbean-ocean-river-mod"
@@ -148,7 +148,7 @@ variants:
           - OceanRiverMod/ShallowWater_669999.dat
           - OceanRiverMod/DeepSea_Grass.dat
   - variant:
-      mayorbean:ocean-river-mod:shallow: "669999"
+      mayorbean:ocean-river-mod:shallow: blue
       mayorbean:ocean-river-mod:deep: "marsh"
     assets:
       - assetId: "mayorbean-ocean-river-mod"
@@ -157,7 +157,7 @@ variants:
           - OceanRiverMod/DeepSea_Marsh.dat
   - variant:
       mayorbean:ocean-river-mod:shallow: "grass"
-      mayorbean:ocean-river-mod:deep: 5f5f00
+      mayorbean:ocean-river-mod:deep: moss-green
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
@@ -165,7 +165,7 @@ variants:
           - OceanRiverMod/DeepSea_5F5F00.dat
   - variant:
       mayorbean:ocean-river-mod:shallow: "grass"
-      mayorbean:ocean-river-mod:deep: "669966"
+      mayorbean:ocean-river-mod:deep: asparagus
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
@@ -173,7 +173,7 @@ variants:
           - OceanRiverMod/DeepSea_669966.dat
   - variant:
       mayorbean:ocean-river-mod:shallow: "grass"
-      mayorbean:ocean-river-mod:deep: "669999"
+      mayorbean:ocean-river-mod:deep: blue
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
@@ -197,7 +197,7 @@ variants:
           - OceanRiverMod/DeepSea_Marsh.dat
   - variant:
       mayorbean:ocean-river-mod:shallow: "marsh"
-      mayorbean:ocean-river-mod:deep: 5f5f00
+      mayorbean:ocean-river-mod:deep: moss-green
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
@@ -205,7 +205,7 @@ variants:
           - OceanRiverMod/DeepSea_5F5F00.dat
   - variant:
       mayorbean:ocean-river-mod:shallow: "marsh"
-      mayorbean:ocean-river-mod:deep: "669966"
+      mayorbean:ocean-river-mod:deep: asparagus
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:
@@ -213,7 +213,7 @@ variants:
           - OceanRiverMod/DeepSea_669966.dat
   - variant:
       mayorbean:ocean-river-mod:shallow: "marsh"
-      mayorbean:ocean-river-mod:deep: "669999"
+      mayorbean:ocean-river-mod:deep: blue
     assets:
       - assetId: "mayorbean-ocean-river-mod"
         include:

--- a/src/yaml/mayorbean/ocean-river-mod.yaml
+++ b/src/yaml/mayorbean/ocean-river-mod.yaml
@@ -1,12 +1,14 @@
 group: "mayorbean"
 name: "ocean-river-mod"
 version: "1.1"
-subfolder: "150-mods"
+subfolder: "170-terrain"
 info:
   summary: Ocean River Mod
-  description: |
+  description: >
     Replaces the ingame water textures. The watercolor will differ depending on depth and viewing angle. It looks best at a waterdepth between 0m and 30m.
-  author: "mayorbean"
+
+    This is an SD water mod.
+  author: "MayorBean"
   images:
     - https://www.simtropolis.com/objects/screens/0002/0becdafa3a030cad2381f492fc4e04c0-__MBCC-ORM-1.1final-UpdateFiles.jpg
     - https://www.simtropolis.com/objects/screens/0002/0becdafa3a030cad2381f492fc4e04c0-OceanRiverSet1.jpg

--- a/src/yaml/paeng/streetside-diagonal-parking.yaml
+++ b/src/yaml/paeng/streetside-diagonal-parking.yaml
@@ -33,7 +33,7 @@ name: streetside-diagonal-parking-textures
 version: "1.0"
 subfolder: 100-props-textures
 info:
-  summary: Textures for Peng's StreetSide Diagonal Parking (SSDP)
+  summary: Textures for paeng's StreetSide Diagonal Parking (SSDP)
   author: paeng
   website: https://community.simtropolis.com/files/file/31162-paengs-streetside-diagonal-parking-ssdp/
 assets:

--- a/src/yaml/paeng/streetside-diagonal-parking.yaml
+++ b/src/yaml/paeng/streetside-diagonal-parking.yaml
@@ -9,7 +9,7 @@ info:
       - Standalone
       - Parks205 Sidings
       - BikePaths-compatible
-    
+
     All items can be found in the 'Transport | Miscellaneous' menu with custom icons.
     The Left/Right Ends of each version are functional parking and generate a small income.
     All items are compatible with any installed sidewalk mods.

--- a/src/yaml/paeng/streetside-diagonal-parking.yaml
+++ b/src/yaml/paeng/streetside-diagonal-parking.yaml
@@ -24,6 +24,22 @@ dependencies:
   - bsc:mega-props-sg-vol01
 assets:
   - assetId: paeng-streetside-diagonal-parking
+    exclude:
+      - KEEP_SSDP_Resource.dat
+
+---
+group: paeng
+name: streetside-diagonal-parking-textures
+version: "1.0"
+subfolder: 100-props-textures
+info:
+  summary: Textures for Peng's StreetSide Diagonal Parking (SSDP)
+  author: paeng
+  website: https://community.simtropolis.com/files/file/31162-paengs-streetside-diagonal-parking-ssdp/
+assets:
+  - assetId: paeng-streetside-diagonal-parking
+    include:
+      - KEEP_SSDP_Resource.dat
 
 ---
 assetId: paeng-streetside-diagonal-parking

--- a/src/yaml/parisian/220-south-central-park.yaml
+++ b/src/yaml/parisian/220-south-central-park.yaml
@@ -1,0 +1,32 @@
+group: parisian
+name: 220-south-central-park
+version: "1.1.0"
+subfolder: 360-landmark
+info:
+  summary: 220 South Central Park
+  description: |
+    220 South Central Park, is a skyscraper in Midtown Manhattan on 58th W between 7th and 8th.
+    This building is part of the new skyline of New York (along with the Nordstrom in the same area).
+    This file contains only the tallest structure of the complex (including 2 buildings, one measuring 952ft (290m - 66floors) and another one smaller, located on the central park south lane, (not included in this file).
+  author: Parisian
+  website: https://community.simtropolis.com/files/file/30728-nybt-parisian-220-south-central-park/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2015_08/220_Central_Park_South7.thumb.png.e6b7ba7adff553e3c5af6545e6b6e623.png
+    - https://www.simtropolis.com/objects/screens/monthly_2015_08/220_Central_Park_South2.thumb.png.64cbf0b9d11345cca80ee55cf54fac9c.png
+    - https://www.simtropolis.com/objects/screens/monthly_2015_08/200_South_Central_Park2.thumb.png.61172ab2e4b16ebb6c36cd4061e26fcc.png
+    - https://www.simtropolis.com/objects/screens/monthly_2015_08/200_South_Central_Park.thumb.png.ebc75c9709c624cc66de9eec401d6e80.png
+    - https://www.simtropolis.com/objects/screens/monthly_2015_08/200_South_Central_Park3.thumb.png.c056d1a1d68226ea4984199f87885bc7.png
+    - https://www.simtropolis.com/objects/screens/monthly_2015_08/200_South_Central_Park4.thumb.png.6873e70fdd8ada04def0419953e18384.png
+    - https://www.simtropolis.com/objects/screens/monthly_2022_07/62e3c57f35bc6_NYBTParisian220CentralParkSouthv1-d.thumb.jpg.7327b109948eec2e90360c0e228cbd7b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_07/62e3c57fe419f_NYBTParisian220CentralParkSouthv1-n.thumb.jpg.45585309c8619f0899e8a1854b26f4e4.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_07/62e3c5804bbf3_NYBTParisian220CentralParkSouthv2-d.thumb.jpg.35bfad42de36ab34e6686f8e780b9919.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_07/62e3c580c6daf_NYBTParisian220CentralParkSouthv2-n.thumb.jpg.c648e91e12a479be487bd9ff1c187406.jpg
+
+assets:
+- assetId: parisian-220-south-central-park-v2
+
+---
+assetId: parisian-220-south-central-park-v2
+version: "1.1.0"
+lastModified: "2022-07-29T11:33:14Z"
+url: https://community.simtropolis.com/files/file/30728-nybt-parisian-220-south-central-park/?do=download&r=194844

--- a/src/yaml/parisian/220-south-central-park.yaml
+++ b/src/yaml/parisian/220-south-central-park.yaml
@@ -23,7 +23,7 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2022_07/62e3c580c6daf_NYBTParisian220CentralParkSouthv2-n.thumb.jpg.c648e91e12a479be487bd9ff1c187406.jpg
 
 assets:
-- assetId: parisian-220-south-central-park-v2
+  - assetId: parisian-220-south-central-park-v2
 
 ---
 assetId: parisian-220-south-central-park-v2

--- a/src/yaml/parisian/220-south-central-park.yaml
+++ b/src/yaml/parisian/220-south-central-park.yaml
@@ -3,11 +3,11 @@ name: 220-south-central-park
 version: "1.1.0"
 subfolder: 360-landmark
 info:
-  summary: 220 South Central Park
+  summary: 220 South Central Park (NYBT)
   description: |
     220 South Central Park, is a skyscraper in Midtown Manhattan on 58th W between 7th and 8th.
     This building is part of the new skyline of New York (along with the Nordstrom in the same area).
-    This file contains only the tallest structure of the complex (including 2 buildings, one measuring 952ft (290m - 66floors) and another one smaller, located on the central park south lane, (not included in this file).
+    This file contains only the tallest structure of the complex (including 2 buildings, one measuring 952ft (290m - 66floors) and another one smaller, located on the central park south lane, not included in this file).
   author: Parisian
   website: https://community.simtropolis.com/files/file/30728-nybt-parisian-220-south-central-park/
   images:

--- a/src/yaml/peg/abyss-garbage-chute.yaml
+++ b/src/yaml/peg/abyss-garbage-chute.yaml
@@ -4,7 +4,7 @@ version: "2.05"
 subfolder: 500-utilities
 info:
   summary: Abyss Garbage Chute
-  description: |
+  description: >
     For hundreds of years, Sim-kind labored under the belief that the world was round. But then, as any schoolchild will tell you, Simlumbus set off to sail around the world in his three ships; the Simna, the Simta & the Santa Simria. He sailed off the edge, into the Abyss and was never heard from again. And that's why nothing is named after him today.
 
     With the modern invention of aviation and orthographic gaming views, we can now clearly see the edge of our world. Today, we never attempt to navigate beyond it without the protection of The Yellow Arrow. Some scientists... and far too many philosophers, have pondered as to what lies at the bottom of The Abyss. But even today, no one really knows and most of us just don't care.
@@ -19,7 +19,7 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_11_2004/thumb-76dfbcf9da1a4cb3ef23be96d05017b1-product_image2.jpg
 
 dependencies:
-  - peg:cdk-rec-seawall-kit-vol-1
+  - peg:cdk-rec-seawall-kit-vol1
 assets:
   - assetId: peg-abyss-garbage-chute
 

--- a/src/yaml/peg/abyss-garbage-chute.yaml
+++ b/src/yaml/peg/abyss-garbage-chute.yaml
@@ -8,7 +8,7 @@ info:
     For hundreds of years, Sim-kind labored under the belief that the world was round. But then, as any schoolchild will tell you, Simlumbus set off to sail around the world in his three ships; the Simna, the Simta & the Santa Simria. He sailed off the edge, into the Abyss and was never heard from again. And that's why nothing is named after him today.
 
     With the modern invention of aviation and orthographic gaming views, we can now clearly see the edge of our world. Today, we never attempt to navigate beyond it without the protection of The Yellow Arrow. Some scientists... and far too many philosophers, have pondered as to what lies at the bottom of The Abyss. But even today, no one really knows and most of us just don't care.
-    
+
     Capitalizing on this general uncaring spirit, Pegadyne Industries has developed the new Garbage Chute... a small & affordable refuse disposal system that simply tosses our trash over the side. Why allow it to pile up when we can just as easily chuck it into the Abyss? Oh sure, the environmentalists are all in a huff... claiming that the Abyss will be ruined for future generations. And of course, a few attorneys have filed lawsuits claiming to represent the 'Denizens of The Abyss'. But the primary concern has been focused on what actually happens to the trash.
 
     One popular theory is that it simply burns up in the fires of Hell. But federally subsidized research, supported by historic maps that clearly state that "Here There Be Dragons...", indicates that these dragons consider garbage to be a 'delicacy' and delightfully gobble it up with no complaint.

--- a/src/yaml/peg/cdk-rec-seawall-kit.yaml
+++ b/src/yaml/peg/cdk-rec-seawall-kit.yaml
@@ -1,9 +1,9 @@
 group: peg
-name: cdk-rec-seawall-kit-vol-1
+name: cdk-rec-seawall-kit-vol1
 version: "1.0"
 subfolder: 100-props-textures
 info:
-  summary: CDK-REC Seawall Kit Vol 1
+  summary: CDK-REC Seawall Kit Vol. 1
   description: |
     Although this file was intended primarily as a dependency for future PEG-CDK REC lots, it can also be used by lot developers to create their own CDK styled lots.
     The official CDK REC lots use single piece, custom foundation props for each lot which are fixed in size to the specific lot and are largely not re-useable.
@@ -15,10 +15,10 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_02_2005/thumb-18fcced3f66c544b98d15efc023340a7-product_image2.jpg
 
 assets:
-  - assetId: peg-cdk-rec-seawall-kit-vol-1
+  - assetId: peg-cdk-rec-seawall-kit-vol1
 
 ---
-assetId: peg-cdk-rec-seawall-kit-vol-1
+assetId: peg-cdk-rec-seawall-kit-vol1
 version: "1.0"
 lastModified: "2005-02-24T19:19:33Z"
 url: https://community.simtropolis.com/files/file/11773-peg-cdk-rec-seawall-kit-vol-1/?do=download

--- a/src/yaml/rivit/thalys-high-speed-train.yaml
+++ b/src/yaml/rivit/thalys-high-speed-train.yaml
@@ -1,0 +1,18 @@
+group: "rivit"
+name: "thalys-high-speed-train"
+version: "1.0"
+subfolder: "710-automata"
+assets:
+- assetId: "rivit-thalys-high-speed-train"
+info:
+  summary: "Replaces the passenger rail and HSR automata with a Thalys model"
+  author: "rivit"
+  images:
+    - "https://www.simtropolis.com/objects/screens/monthly_2017_10/Thalys.jpg.f045e81272851eea390036972350a9c9.jpg"
+  website: "https://community.simtropolis.com/files/file/31974-thalys-high-speed-train/"
+
+---
+url: "https://community.simtropolis.com/files/file/31974-thalys-high-speed-train/?do=download"
+assetId: "rivit-thalys-high-speed-train"
+version: "1.0"
+lastModified: "2017-10-14T22:34:50Z"

--- a/src/yaml/rivit/thalys-high-speed-train.yaml
+++ b/src/yaml/rivit/thalys-high-speed-train.yaml
@@ -1,15 +1,35 @@
 group: "rivit"
-name: "thalys-high-speed-train"
+name: "thalys-high-speed-train-rail"
 version: "1.0"
 subfolder: "710-automata"
-assets:
-- assetId: "rivit-thalys-high-speed-train"
 info:
-  summary: "Replaces the passenger rail and HSR automata with a Thalys model"
+  summary: "Replaces the passenger rail automata with a Thalys model"
   author: "rivit"
   images:
     - "https://www.simtropolis.com/objects/screens/monthly_2017_10/Thalys.jpg.f045e81272851eea390036972350a9c9.jpg"
   website: "https://community.simtropolis.com/files/file/31974-thalys-high-speed-train/"
+
+assets:
+  - assetId: "rivit-thalys-high-speed-train"
+    include:
+      - Thalys Train.dat
+
+---
+group: "rivit"
+name: "thalys-high-speed-train-hsr"
+version: "1.0"
+subfolder: "710-automata"
+info:
+  summary: "Replaces the HSR automata with a Thalys model"
+  author: "rivit"
+  images:
+    - "https://www.simtropolis.com/objects/screens/monthly_2017_10/Thalys.jpg.f045e81272851eea390036972350a9c9.jpg"
+  website: "https://community.simtropolis.com/files/file/31974-thalys-high-speed-train/"
+
+assets:
+  - assetId: "rivit-thalys-high-speed-train"
+    include:
+      - Thalys HSR.dat
 
 ---
 url: "https://community.simtropolis.com/files/file/31974-thalys-high-speed-train/?do=download"

--- a/src/yaml/rivit/thalys-high-speed-train.yaml
+++ b/src/yaml/rivit/thalys-high-speed-train.yaml
@@ -4,6 +4,8 @@ version: "1.0"
 subfolder: "710-automata"
 info:
   summary: "Replaces the passenger rail automata with a Thalys model"
+  description: >
+    See also `pkg=rivit:thalys-high-speed-train-hsr`.
   author: "rivit"
   images:
     - "https://www.simtropolis.com/objects/screens/monthly_2017_10/Thalys.jpg.f045e81272851eea390036972350a9c9.jpg"
@@ -21,6 +23,8 @@ version: "1.0"
 subfolder: "710-automata"
 info:
   summary: "Replaces the HSR automata with a Thalys model"
+  description: >
+    See also `pkg=rivit:thalys-high-speed-train-rail`.
   author: "rivit"
   images:
     - "https://www.simtropolis.com/objects/screens/monthly_2017_10/Thalys.jpg.f045e81272851eea390036972350a9c9.jpg"

--- a/src/yaml/rretail/roadside-rest-area.yaml
+++ b/src/yaml/rretail/roadside-rest-area.yaml
@@ -4,8 +4,8 @@ version: "1.1"
 subfolder: 700-transit
 info:
   summary: Roadside Rest Area
-  description: |
-    This the rest area building and lot are inspired by the design of the Campbell, NY rest area along I-86 in western New York.
+  description: >
+    This rest area building and lot are inspired by the design of the Campbell, NY rest area along I-86 in western New York.
 
     It comes in a size 4x15 lot which acts as a bus stop in game. Both lots also feature transit connection with one way streets for a better transition with the NAM system.
 

--- a/src/yaml/rretail/roadside-rest-area.yaml
+++ b/src/yaml/rretail/roadside-rest-area.yaml
@@ -1,0 +1,58 @@
+group: rretail
+name: roadside-rest-area
+version: "1.1"
+subfolder: 700-transit
+info:
+  summary: Roadside Rest Area
+  description: |
+    This the rest area building and lot are inspired by the design of the Campbell, NY rest area along I-86 in western New York.
+
+    It comes in a size 4x15 lot which acts as a bus stop in game. Both lots also feature transit connection with one way streets for a better transition with the NAM system.
+
+  author: RRetail, kingofsimcity
+  website: https://community.simtropolis.com/files/file/32713-roadside-rest-area/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_01/5c390a715e64a_RRRestArea.jpg.ad03d3d89fd442749dad7f6e6ad26024.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_01/5c390bfd4ab34_RRRestArea.jpg.777fc21e2c96ebc42e434dd806cb551d.jpg
+
+dependencies:
+  - mushymushy:na-53ft-trailers-vol1
+  - bsc:mega-props-dae-vol01
+  - shk:parking-pack
+  - supershk:mega-parking-textures
+  - supershk:fa3-parking-textures
+  - kingofsimcity:superpaths-pathway-textures
+  - rretail:mega-prop-pack-vol1
+  - girafe:ashes
+  - girafe:beeches
+  - girafe:berries
+  - girafe:birches
+  - girafe:chestnuts
+  - girafe:elms
+  - girafe:feather-grass
+  - girafe:hedges
+  - girafe:lindens
+  - girafe:maples-v2
+  - girafe:narcissus
+  - girafe:poplars
+  - girafe:rowan-trees
+  - girafe:sparaxis
+  - girafe:walnut-trees
+
+variants:
+  - variant: { driveside: right }
+    assets:
+      - assetId: rretail-roadside-rest-area
+        exclude:
+          - _LHD_
+  - variant: { driveside: left }
+    assets:
+      - assetId: rretail-roadside-rest-area
+        exclude:
+          - _RHD_
+
+---
+assetId: rretail-roadside-rest-area
+version: "1.1"
+lastModified: "2020-06-20T00:59:49Z"
+url: https://community.simtropolis.com/files/file/32713-roadside-rest-area/?do=download

--- a/src/yaml/scotty222/one-us-bank-plaza.yaml
+++ b/src/yaml/scotty222/one-us-bank-plaza.yaml
@@ -8,7 +8,7 @@ info:
     One US Bank Plaza, St Louis, MO
 
     Comes as a ploppable and growable
-     
+
     CO$$
     3500 jobs
     4x2 lot

--- a/src/yaml/scotty222/safeco-plaza.yaml
+++ b/src/yaml/scotty222/safeco-plaza.yaml
@@ -6,7 +6,7 @@ info:
   summary: Safeco Plaza
   description: |
     Safeco Plaza, previously 1001 Fourth Avenue Plaza, and the Seattle First National Bank Building is a 50 storey, 192 m (630 ft) skyscraper in downtown Seattle, WA. The tower is nicknamed the Box the Space Needle came in by locals. When the tower was completed in 1969 it dwarfed the Smith Tower which had been the cities tallest since 1914 and edged out the space needle.
-     
+
     Includes a CO$$ grow and a CO$$ plop both on a 3x4 lot and both with 4749 jobs.
   author: scotty222
   website: https://community.simtropolis.com/files/file/29721-safeco-plaza/

--- a/src/yaml/scotty222/safeco-plaza.yaml
+++ b/src/yaml/scotty222/safeco-plaza.yaml
@@ -4,8 +4,8 @@ version: "1.0"
 subfolder: 300-commercial
 info:
   summary: Safeco Plaza
-  description: |
-    Safeco Plaza, previously 1001 Fourth Avenue Plaza, and the Seattle First National Bank Building is a 50 storey, 192 m (630 ft) skyscraper in downtown Seattle, WA. The tower is nicknamed the Box the Space Needle came in by locals. When the tower was completed in 1969 it dwarfed the Smith Tower which had been the cities tallest since 1914 and edged out the space needle.
+  description: >
+    Safeco Plaza, previously 1001 Fourth Avenue Plaza, and the Seattle First National Bank Building is a 50 storey, 192 m (630 ft) skyscraper in downtown Seattle, WA. The tower is nicknamed "the Box the Space Needle came in" by locals. When the tower was completed in 1969 it dwarfed the Smith Tower which had been the cities tallest since 1914 and edged out the Space Needle.
 
     Includes a CO$$ grow and a CO$$ plop both on a 3x4 lot and both with 4749 jobs.
   author: scotty222

--- a/src/yaml/scotty222/toronto-dominion-tower.yaml
+++ b/src/yaml/scotty222/toronto-dominion-tower.yaml
@@ -5,14 +5,13 @@ subfolder: 300-commercial
 info:
   summary: Toronto Dominion Tower
   description: |
-    TD tower is located at 700 West Georgia Street in Downtown Vancouver, BC, Canada
-    The skyscraper stands at 127 m or 30 stories tall and was completed in 1972.
+    TD tower is located at 700 West Georgia Street in Downtown Vancouver, BC, Canada. The skyscraper stands at 127 m or 30 stories tall and was completed in 1972.
     Included is a CO$$ Growable and Ploppable
 
-    3x3 lot
-    1565 CO$$ jobs
-    Stage 8
-    Houston & Euro Tilesets
+    - 3x3 lot
+    - 1565 CO$$ jobs
+    - Stage 8
+    - Houston & Euro Tilesets
   author: scotty222
   website: https://community.simtropolis.com/files/file/28578-toronto-dominion-tower/
   images:

--- a/src/yaml/scotty222/toronto-dominion-tower.yaml
+++ b/src/yaml/scotty222/toronto-dominion-tower.yaml
@@ -8,7 +8,7 @@ info:
     TD tower is located at 700 West Georgia Street in Downtown Vancouver, BC, Canada
     The skyscraper stands at 127 m or 30 stories tall and was completed in 1972.
     Included is a CO$$ Growable and Ploppable
-     
+
     3x3 lot
     1565 CO$$ jobs
     Stage 8

--- a/src/yaml/simfox/bashnja-na-naberezhnoj-c.yaml
+++ b/src/yaml/simfox/bashnja-na-naberezhnoj-c.yaml
@@ -9,26 +9,8 @@ info:
 
     This package includes 3 5x4 lots:
       - 1 landmark lot
-      - 1 growable CO$$$ stage8 lot
+      - 1 growable CO$$$ stage8 lot (Euro tileset)
       - 1 plop CO$$$ lot
-
-    Jobs
-      - CO$$$: 7642
-      - CO$$: 10924
-    Consumption:
-      - power: 277
-      - water: 2961
-    Pollution/radii
-      - air: 19/7
-      - water:19/8
-      - garbage:6/0
-      - radiation:0/0
-    Other numbers:
-      - building value: 85429
-      - bulldoze cost: 3105
-      - landmark effects(for landmark lot): 10 over 256
-      - mayor ratiings (for landmark lot): 90 over 30
-      - tileset (for growable lot): euro
   author: SimFox
   website: https://community.simtropolis.com/files/file/19696-bashnja-na-naberezhnoj-c/
   images:

--- a/src/yaml/simfox/seagram-building.yaml
+++ b/src/yaml/simfox/seagram-building.yaml
@@ -6,9 +6,9 @@ info:
   summary: Seagram Building
   description: |
     Seagram Building by Ludwig Mies van der Rohe built for Canadian booze peddler Seagram and Songs Plc is considered to be both finest example and originator of "corporate box" - or so called International Style.
-    
+
     Apparent simplicity is deceiving. By the time 38 storey tower on New York Park Avenue has been opened in 1958 it was the most expensive skyscraper ever built, and it curtain wall made out of solid bronze and bronze tinted glass still remains the most expensive facade to this day!
-    
+
     This download includes:
      - Seagram building model file
      - 4x6 Ploppable Lot with Co$$$ jobs
@@ -17,16 +17,16 @@ info:
 
     Key Stats:
                     Grow                      Plop                     Landmark
-    Jobs            4328 Co$$$ / 6187 Co$$    4328 Co$$$ / 6187 Co$$   N/A        
-    Plop Cost       N/A                       36 408$                  232 800$        
-    Monthly Cost    N/A                       N/A                      282$        
-    Polution / radius:                                       
-     air            23 / 6                    23 / 6                   6 / 1        
-     water          23 / 7                    23 / 7                   5 / 2        
-     garbage        9 / 0                     9 / 0                    25 / 0        
-    Consumption:                                       
-     water          1683                      1683                     0        
-     power          156                       156                      170        
+    Jobs            4328 Co$$$ / 6187 Co$$    4328 Co$$$ / 6187 Co$$   N/A
+    Plop Cost       N/A                       36 408$                  232 800$
+    Monthly Cost    N/A                       N/A                      282$
+    Polution / radius:
+     air            23 / 6                    23 / 6                   6 / 1
+     water          23 / 7                    23 / 7                   5 / 2
+     garbage        9 / 0                     9 / 0                    25 / 0
+    Consumption:
+     water          1683                      1683                     0
+     power          156                       156                      170
 
   author: SimFox
   website: https://community.simtropolis.com/files/file/24680-nybt-seagram-building-darknite-version/

--- a/src/yaml/simfox/seagram-building.yaml
+++ b/src/yaml/simfox/seagram-building.yaml
@@ -7,26 +7,13 @@ info:
   description: |
     Seagram Building by Ludwig Mies van der Rohe built for Canadian booze peddler Seagram and Songs Plc is considered to be both finest example and originator of "corporate box" - or so called International Style.
 
-    Apparent simplicity is deceiving. By the time 38 storey tower on New York Park Avenue has been opened in 1958 it was the most expensive skyscraper ever built, and it curtain wall made out of solid bronze and bronze tinted glass still remains the most expensive facade to this day!
+    Apparent simplicity is deceiving. By the time 38 storey tower on New York Park Avenue has been opened in 1958 it was the most expensive skyscraper ever built, and its curtain wall made out of solid bronze and bronze tinted glass still remains the most expensive facade to this day!
 
     This download includes:
      - Seagram building model file
      - 4x6 Ploppable Lot with Co$$$ jobs
      - 4x6 Growable Lot
      - 4x6 Landmark Lot
-
-    Key Stats:
-                    Grow                      Plop                     Landmark
-    Jobs            4328 Co$$$ / 6187 Co$$    4328 Co$$$ / 6187 Co$$   N/A
-    Plop Cost       N/A                       36 408$                  232 800$
-    Monthly Cost    N/A                       N/A                      282$
-    Polution / radius:
-     air            23 / 6                    23 / 6                   6 / 1
-     water          23 / 7                    23 / 7                   5 / 2
-     garbage        9 / 0                     9 / 0                    25 / 0
-    Consumption:
-     water          1683                      1683                     0
-     power          156                       156                      170
 
   author: SimFox
   website: https://community.simtropolis.com/files/file/24680-nybt-seagram-building-darknite-version/

--- a/src/yaml/t-wrecks/industrial-revolution-mod-i-d-filler-set-1.yaml
+++ b/src/yaml/t-wrecks/industrial-revolution-mod-i-d-filler-set-1.yaml
@@ -21,10 +21,7 @@ info:
 dependencies:
   - sfbt:essentials
   - bsc:mega-props-jes-vol01
-  - bsc:mega-props-jes-vol01
   - bsc:mega-props-jes-vol02
-  - bsc:mega-props-jes-vol02
-  - bsc:mega-props-gascooker-vol01
   - bsc:mega-props-gascooker-vol01
   - ncd:rail-yard-and-spur-mega-pak-1
 assets:

--- a/src/yaml/t-wrecks/industrial-revolution-mod-i-d-filler-set-1.yaml
+++ b/src/yaml/t-wrecks/industrial-revolution-mod-i-d-filler-set-1.yaml
@@ -3,9 +3,9 @@ name: industrial-revolution-mod-i-d-filler-set-1
 version: "1.1"
 subfolder: 400-industrial
 info:
-  summary: Industrial Revolution Mod - I-D Filler Set 1
-  description: |
-    This is a set of 12 ploppable filler lots for dirty industry (I-D) that can be used to complement grown industrial areas with some open yards, walls, and several types of cargo stacked outside. The set has been made for the `memo:industrial-revolution-mod` and, as such, blends in well with I-D areas because it uses the same base texture, and the brick walls look good in connection with older brick factories and their side buildings.
+  summary: IRM - Ploppable I-D Filler Set 1
+  description: >
+    This is a set of 12 ploppable filler lots for dirty industry (I-D) that can be used to complement grown industrial areas with some open yards, walls, and several types of cargo stacked outside. The set has been made for the `pkg=memo:industrial-revolution-mod` and, as such, blends in well with I-D areas because it uses the same base texture, and the brick walls look good in connection with older brick factories and their side buildings.
 
     You will find these lots in the landmark menu, conveniently grouped together.
   author: T Wrecks

--- a/src/yaml/t-wrecks/industrial-revolution-mod-i-ht-filler-set-1.yaml
+++ b/src/yaml/t-wrecks/industrial-revolution-mod-i-ht-filler-set-1.yaml
@@ -3,9 +3,9 @@ name: industrial-revolution-mod-i-ht-filler-set-1
 version: "1.0"
 subfolder: 400-industrial
 info:
-  summary: Industrial Revolution Mod - I-HT Filler Set 1
-  description: |
-    This is a set of 12 ploppable filler lots for high-tech industry (I-HT) that can be used to complement grown industrial areas with some open yards, walls, and several types of cargo stacked outside. The set has been made for the `memo:industrial-revolution-mod` and, as such, blends in well with I-HT areas because it uses the same base texture, and the green fences look rather modern and suitable for high-tech industry.
+  summary: IRM - Ploppable I-HT Filler Set 1
+  description: >
+    This is a set of 12 ploppable filler lots for high-tech industry (I-HT) that can be used to complement grown industrial areas with some open yards, walls, and several types of cargo stacked outside. The set has been made for the `pkg=memo:industrial-revolution-mod` and, as such, blends in well with I-HT areas because it uses the same base texture, and the green fences look rather modern and suitable for high-tech industry.
 
     You will find these lots in the landmark menu, conveniently grouped together right under the I-M fillers.
   author: T Wrecks
@@ -19,7 +19,7 @@ info:
 
 dependencies:
   - sfbt:essentials
-  - maxis:buildings-as-props
+  - t-wrecks:maxis-prop-names-and-query-fix
   - bsc:mega-props-jes-vol01
   - bsc:mega-props-jes-vol02
   - bsc:mega-props-gascooker-vol01

--- a/src/yaml/t-wrecks/industrial-revolution-mod-i-m-filler-set-1.yaml
+++ b/src/yaml/t-wrecks/industrial-revolution-mod-i-m-filler-set-1.yaml
@@ -3,9 +3,9 @@ name: industrial-revolution-mod-i-m-filler-set-1
 version: "1.0"
 subfolder: 400-industrial
 info:
-  summary: Industrial Revolution Mod - I-M Filler Set 1
-  description: |
-    This is a set of 12 ploppable filler lots for manufacturing industry (I-M) that can be used to complement grown industrial areas with some open yards, walls, and several types of cargo stacked outside. The set has been made for the `memo:industrial-revolution-mod` and, as such, blends in well with I-M areas because it uses the same base texture, and the rather neutrally designed walls are a good compromise between old and modern, which will make them look good in connection with any I-M facilities.
+  summary: IRM - Ploppable I-M Filler Set 1
+  description: >
+    This is a set of 12 ploppable filler lots for manufacturing industry (I-M) that can be used to complement grown industrial areas with some open yards, walls, and several types of cargo stacked outside. The set has been made for the `pkg=memo:industrial-revolution-mod` and, as such, blends in well with I-M areas because it uses the same base texture, and the rather neutrally designed walls are a good compromise between old and modern, which will make them look good in connection with any I-M facilities.
 
     You will find these lots in the landmark menu, conveniently grouped together right under the I-D fillers.
   author: T Wrecks

--- a/src/yaml/teirusu/rain-tool.yaml
+++ b/src/yaml/teirusu/rain-tool.yaml
@@ -5,8 +5,12 @@ subfolder: "150-mods"
 assets:
 - assetId: "teirusu-rain-tool"
 info:
-  summary: "Contains the 'Rain Tool' that is needed to construct land bridges or plop water lots above sea level."
-  author: "teirusu"
+  summary: "Helps construct land bridges or plop water lots above sea level"
+  description: >
+    The water created by the rain tool will only last for a single game session.
+    When the city tile is reopened the rain water will no longer be there.
+    The blank terrain can then be filled in with any ploppable water as desired.
+  author: Teirusu
   images:
   - "https://www.simtropolis.com/objects/screens/monthly_04_2012/14c75f03f2f0cf879aef9d515c6d3b92-.jpg"
   - "https://www.simtropolis.com/objects/screens/monthly_04_2012/5f0a9b312733c793a5edcd9c41c9d65a-.jpg"

--- a/src/yaml/teirusu/rain-tool.yaml
+++ b/src/yaml/teirusu/rain-tool.yaml
@@ -1,0 +1,19 @@
+group: "teirusu"
+name: "rain-tool"
+version: "1.0"
+subfolder: "150-mods"
+assets:
+- assetId: "teirusu-rain-tool"
+info:
+  summary: "Contains the 'Rain Tool' that is needed to construct land bridges or plop water lots above sea level."
+  author: "teirusu"
+  images:
+  - "https://www.simtropolis.com/objects/screens/monthly_04_2012/14c75f03f2f0cf879aef9d515c6d3b92-.jpg"
+  - "https://www.simtropolis.com/objects/screens/monthly_04_2012/5f0a9b312733c793a5edcd9c41c9d65a-.jpg"
+  website: "https://community.simtropolis.com/files/file/21531-teirusu-rain-tool-additional-god-mode-terrain-tools-2/"
+
+---
+url: "https://community.simtropolis.com/files/file/21531-teirusu-rain-tool-additional-god-mode-terrain-tools-2/?do=download"
+assetId: "teirusu-rain-tool"
+version: "1.0"
+lastModified: "2009-04-08T02:44:52Z"

--- a/src/yaml/tropod/additional-god-mode-terrain-tools.yaml
+++ b/src/yaml/tropod/additional-god-mode-terrain-tools.yaml
@@ -6,7 +6,7 @@ assets:
 - assetId: "tropod-additional-god-mode-terrain-tools"
 info:
   summary: "Adds four additional terrain tools to 'God Mode'"
-  author: "tropod"
+  author: "Tropod"
   images:
     - https://www.simtropolis.com/objects/screens/0025/e12b69a115ce332c73983cf137620d8b-extra%20terrain%20avatar.jpg
   website: "https://community.simtropolis.com/files/file/21288-additional-god-mode-terrain-tools/"

--- a/src/yaml/tropod/additional-god-mode-terrain-tools.yaml
+++ b/src/yaml/tropod/additional-god-mode-terrain-tools.yaml
@@ -15,4 +15,4 @@ info:
 url: "https://community.simtropolis.com/files/file/21288-additional-god-mode-terrain-tools/?do=download"
 assetId: "tropod-additional-god-mode-terrain-tools"
 version: "1.0"
-lastModified: "2009-04-08T02:44:52Z"
+lastModified: "2003-07-16T23:00:00Z"

--- a/src/yaml/tropod/additional-god-mode-terrain-tools.yaml
+++ b/src/yaml/tropod/additional-god-mode-terrain-tools.yaml
@@ -1,0 +1,18 @@
+group: "tropod"
+name: "additional-god-mode-terrain-tools"
+version: "1.0"
+subfolder: "150-mods"
+assets:
+- assetId: "tropod-additional-god-mode-terrain-tools"
+info:
+  summary: "Adds four additional terrain tools to 'God Mode'"
+  author: "tropod"
+  images:
+    - https://www.simtropolis.com/objects/screens/0025/e12b69a115ce332c73983cf137620d8b-extra%20terrain%20avatar.jpg
+  website: "https://community.simtropolis.com/files/file/21288-additional-god-mode-terrain-tools/"
+
+---
+url: "https://community.simtropolis.com/files/file/21288-additional-god-mode-terrain-tools/?do=download"
+assetId: "tropod-additional-god-mode-terrain-tools"
+version: "1.0"
+lastModified: "2009-04-08T02:44:52Z"

--- a/src/yaml/warrior/god-terraforming-in-mayor-mode.yaml
+++ b/src/yaml/warrior/god-terraforming-in-mayor-mode.yaml
@@ -5,7 +5,7 @@ subfolder: "150-mods"
 assets:
 - assetId: "warrior-god-terraforming-in-mayor-mode"
 info:
-  summary: "Modifies the Mayor Mode Terraforming Menu to include the God terraforming tools."
+  summary: "Adds God Terraforming tools to Mayor Mode Terraforming menu"
   description: |
     This plugin modifies the Mayor Mode Terraforming Menu to include the God terraforming tools.
     This is meant to replace the Ctrl-Alt-Shift trick.

--- a/src/yaml/warrior/god-terraforming-in-mayor-mode.yaml
+++ b/src/yaml/warrior/god-terraforming-in-mayor-mode.yaml
@@ -1,0 +1,24 @@
+group: "warrior"
+name: "god-terraforming-in-mayor-mode"
+version: "1.0"
+subfolder: "150-mods"
+assets:
+- assetId: "warrior-god-terraforming-in-mayor-mode"
+info:
+  summary: "Modifies the Mayor Mode Terraforming Menu to include the God terraforming tools."
+  description: |
+    This plugin modifies the Mayor Mode Terraforming Menu to include the God terraforming tools.
+    This is meant to replace the Ctrl-Alt-Shift trick.
+  author: "warrior"
+  images:
+  - "https://www.simtropolis.com/objects/screens/0032/thumb-e1eb12a2255c85a230d56a4b090a5b5e-170fd8a426a570ecd605db07e439fdc9-lex_015.jpg"
+  website: "https://community.simtropolis.com/files/file/20092-god-terraforming-in-mayor-mode/"
+
+---
+url: "https://community.simtropolis.com/files/file/20092-god-terraforming-in-mayor-mode/?do=download"
+assetId: "warrior-god-terraforming-in-mayor-mode"
+version: "1.0"
+lastModified: "2011-03-31T20:36:09Z"
+archiveType:
+  format: Clickteam
+  version: "40"


### PR DESCRIPTION
This PR adds a bunch of metadata as part of an effort to port most of my existing plugins folder to sc4pac (more to follow). Most of the metadata has been generated by a script that scrapes the Simtropolis url.

There's one thing I'd like to discuss. The `rivit:thalys-high-speed-train` actually contains two files: one to replace the passenger rail train, and one to replace the HSR train. Do you think it makes sense to split this into two separate packages?