### PR TITLE
Add various sfbt dependencies

### DIFF
--- a/src/yaml/sfbt/kenworth-and-royal-railway-props.yaml
+++ b/src/yaml/sfbt/kenworth-and-royal-railway-props.yaml
@@ -1,13 +1,12 @@
 group: sfbt
-name: kenworth-and-royal-railway-props
+name: kenworth-royal-railway-props
 version: "1"
 subfolder: 100-props-textures
 info:
-  summary: Kentworth and Royal Railway Props
+  summary: Railway Props by Kenworth and Royal
   description: |
     This download contains the engines BR 143, BR 218, BR 232, BR 185 (in three different colors), DR 243, various freight cars, passenger cars in three different colors (first and second class, plus control cars), German buffers, additional catenaries and a pylon light for sidings.
-
-    This prop pack contains more than 40 different railway props. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own. In the Lot Editor, all signals are listed with the prefix "SFBT\_Train\_...", so they are neatly grouped for easier finding. Most of the props are also available as timed versions, this is indicated by two numbers (i. e. "7-11" when the prop is visible from 7 AM to 11 AM) in the name.
+    This prop pack contains more than 40 different railway props. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lots or similar included.
   author: Kenworth, Royal
   website: https://www.sc4evermore.com/index.php/downloads/download/118-sfbt-props-kenworth-and-royal-railway-props
   images:

--- a/src/yaml/sfbt/kenworth-and-royal-railway-props.yaml
+++ b/src/yaml/sfbt/kenworth-and-royal-railway-props.yaml
@@ -1,9 +1,9 @@
 group: sfbt
-name: railway-props
+name: kenworth-and-royal-railway-props
 version: "1"
 subfolder: 100-props-textures
 info:
-  summary: Railway Props
+  summary: Kentworth and Royal Railway Props
   description: |
     This download contains the engines BR 143, BR 218, BR 232, BR 185 (in three different colors), DR 243, various freight cars, passenger cars in three different colors (first and second class, plus control cars), German buffers, additional catenaries and a pylon light for sidings.
     
@@ -15,10 +15,10 @@ info:
     - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/Eisenbahnprops_02.jpg
 
 assets:
-  - assetId: sfbt-railway-props
+  - assetId: sfbt-kenworth-and-royal-railway-props
 
 ---
-assetId: sfbt-railway-props
+assetId: sfbt-kenworth-and-royal-railway-props
 version: "1"
 lastModified: "2023-08-17T17:36:33.000Z"
 url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=118:sfbt-props-kenworth-and-royal-railway-props&catid=22

--- a/src/yaml/sfbt/kenworth-and-royal-railway-props.yaml
+++ b/src/yaml/sfbt/kenworth-and-royal-railway-props.yaml
@@ -6,7 +6,7 @@ info:
   summary: Kentworth and Royal Railway Props
   description: |
     This download contains the engines BR 143, BR 218, BR 232, BR 185 (in three different colors), DR 243, various freight cars, passenger cars in three different colors (first and second class, plus control cars), German buffers, additional catenaries and a pylon light for sidings.
-    
+
     This prop pack contains more than 40 different railway props. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own. In the Lot Editor, all signals are listed with the prefix "SFBT\_Train\_...", so they are neatly grouped for easier finding. Most of the props are also available as timed versions, this is indicated by two numbers (i. e. "7-11" when the prop is visible from 7 AM to 11 AM) in the name.
   author: Kenworth, Royal
   website: https://www.sc4evermore.com/index.php/downloads/download/118-sfbt-props-kenworth-and-royal-railway-props

--- a/src/yaml/sfbt/kenworth-and-royal-railway-props.yaml
+++ b/src/yaml/sfbt/kenworth-and-royal-railway-props.yaml
@@ -20,4 +20,4 @@ assets:
 assetId: sfbt-kenworth-and-royal-railway-props
 version: "1"
 lastModified: "2023-08-17T17:36:33.000Z"
-url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=118:sfbt-props-kenworth-and-royal-railway-props&catid=22
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=118:sfbt-props-kenworth-and-royal-railway-props

--- a/src/yaml/sfbt/peterycristi-props.yaml
+++ b/src/yaml/sfbt/peterycristi-props.yaml
@@ -1,0 +1,21 @@
+group: sfbt
+name: peterycristi-props
+version: "1"
+subfolder: 100-props-textures
+info:
+  summary: Peterycristi Props
+  description: |
+    This prop pack contains 25 different props from Berlin and the surrounding area. The props are intended for usage on Berlin-related lots for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own. In the Lot Editor, all props are listed with the prefix "SFBT\_PYC\_...", so they are neatly grouped for easier finding.
+  author: Peterycristi
+  website: https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/123-sfbt-props-peterycristi-props
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/peterycristi_Props_01.jpg
+
+assets:
+  - assetId: sfbt-peterycristi-props
+
+---
+assetId: sfbt-peterycristi-props
+version: "1"
+lastModified: "2023-08-17T18:24:20.000Z"
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=123:sfbt-props-peterycristi-props&catid=22

--- a/src/yaml/sfbt/peterycristi-props.yaml
+++ b/src/yaml/sfbt/peterycristi-props.yaml
@@ -4,8 +4,10 @@ version: "1"
 subfolder: 100-props-textures
 info:
   summary: Peterycristi Props
-  description: |
-    This prop pack contains 25 different props from Berlin and the surrounding area. The props are intended for usage on Berlin-related lots for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own. In the Lot Editor, all props are listed with the prefix "SFBT\_PYC\_...", so they are neatly grouped for easier finding.
+  description: >
+    This prop pack contains 25 different props from Berlin and the surrounding area.
+    The props are intended for usage on Berlin-related lots for SimCity 4.
+    The pack only serves as a dependency, there are no lots or similar included.
   author: Peterycristi
   website: https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/123-sfbt-props-peterycristi-props
   images:

--- a/src/yaml/sfbt/peterycristi-props.yaml
+++ b/src/yaml/sfbt/peterycristi-props.yaml
@@ -20,4 +20,4 @@ assets:
 assetId: sfbt-peterycristi-props
 version: "1"
 lastModified: "2023-08-17T18:24:20.000Z"
-url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=123:sfbt-props-peterycristi-props&catid=22
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=123:sfbt-props-peterycristi-props

--- a/src/yaml/sfbt/railway-props.yaml
+++ b/src/yaml/sfbt/railway-props.yaml
@@ -1,0 +1,24 @@
+group: sfbt
+name: railway-props
+version: "1"
+subfolder: 100-props-textures
+info:
+  summary: Railway Props
+  description: |
+    This download contains the engines BR 143, BR 218, BR 232, BR 185 (in three different colors), DR 243, various freight cars, passenger cars in three different colors (first and second class, plus control cars), German buffers, additional catenaries and a pylon light for sidings.
+    
+    This prop pack contains more than 40 different railway props. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own. In the Lot Editor, all signals are listed with the prefix "SFBT\_Train\_...", so they are neatly grouped for easier finding. Most of the props are also available as timed versions, this is indicated by two numbers (i. e. "7-11" when the prop is visible from 7 AM to 11 AM) in the name.
+  author: Kenworth, Royal
+  website: https://www.sc4evermore.com/index.php/downloads/download/118-sfbt-props-kenworth-and-royal-railway-props
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/Eisenbahnprops_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/Eisenbahnprops_02.jpg
+
+assets:
+  - assetId: sfbt-railway-props
+
+---
+assetId: sfbt-railway-props
+version: "1"
+lastModified: "2023-08-17T17:36:33.000Z"
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=118:sfbt-props-kenworth-and-royal-railway-props&catid=22

--- a/src/yaml/sfbt/rambuckel-horse-props.yaml
+++ b/src/yaml/sfbt/rambuckel-horse-props.yaml
@@ -1,0 +1,76 @@
+group: sfbt
+name: rambuckel-horse-props
+version: "1"
+subfolder: 100-props-textures
+info:
+  summary: Rambuckel Horse Props
+  description: |
+    This prop pack is the ultimate pack for everyone who loves horses. It contains more than 300 props with various horses, and a set of horse coaches. The horses (bay horses, grey horses and black horses) and coaches can be used in Lot Editor as props (grouped in various prop families).
+  author: rambuckel, FrankyFour, Andreas
+  website: https://www.sc4evermore.com/index.php/downloads/download/121-sfbt-props-rambuckel-horse-props
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/SFBT_Pferde_Props_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/SFBT_Pferde_Props_02.jpg
+
+assets:
+  - assetId: sfbt-rambuckel-horse-props
+    include:
+      - /SFBT_Props/
+
+---
+group: sfbt
+name: rambuckel-horse-mmps
+version: "1"
+subfolder: 180-flora
+info:
+  summary: Rambuckel Horse MMPs
+  description: |
+    This pack contains 28 different horses as Mayor Mode Ploppables (MMP). There are various grey, brown and black horses, ponies and foals available.
+    
+    Click repeatedly with the left mouse button to select between the individual models. The last model of each plop cycle is "empty", this can be useful if you accidentially selected a wrong item and want to remove it again without using the bulldozer tool.
+
+  author: rambuckel, FrankyFour, Andreas
+  website: https://www.sc4evermore.com/index.php/downloads/download/121-sfbt-props-rambuckel-horse-props
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/SFBT_Pferde_Props_02.jpg
+
+dependencies:
+  - sfbt:rambuckel-horse-props
+assets:
+  - assetId: sfbt-rambuckel-horse-props
+    include:
+      - /SFBT_Horse_MMP.dat
+
+---
+group: sfbt
+name: rambuckel-horse-carriage-mmps
+version: "1"
+subfolder: 180-flora
+info:
+  summary: Rambuckel Horse Carriage MMPs
+  description: |
+    This pack contains various coaches as Mayor Mode Ploppables (MMP).:
+    
+    -   **Ambulance:* These coaches were used for military and civil purposes until about the 1930s. The first coaches were built in the late 19th century when the first Samaritan associations like the Red Cross were founded.
+    -   **Berline:** The Berline is a fully sprung travel coach which got its name from the fact that it was very popular in circles of the Brandenburg nobility in the 17th century.
+    -   **Caleche:** A four-wheel carriage with a cabin and two seats. It’s quite a small coach, but still comfortable.
+    -   **Hansom Cab:** The Hansom Cab was designed and patented by Joseph Hansom in 1834. It is a two-wheel carriage with two seats. Due to its mobility, it was very popular in London and New York.
+    -   **Stage Coach:** These coaches were used for transportation of mail and passengers from 16th century until early 20th century.
+
+  author: rambuckel, FrankyFour, Andreas
+  website: https://www.sc4evermore.com/index.php/downloads/download/121-sfbt-props-rambuckel-horse-props
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/SFBT_Pferde_Props_01.jpg
+
+dependencies:
+  - sfbt:rambuckel-horse-props
+assets:
+  - assetId: sfbt-rambuckel-horse-props
+    include:
+      - /SFBT_Horse_Carriage_MMP.dat
+
+---
+assetId: sfbt-rambuckel-horse-props
+version: "1"
+lastModified: "2023-08-17T18:13:36.000Z"
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=121:sfbt-props-rambuckel-horse-props&catid=22

--- a/src/yaml/sfbt/rambuckel-horse-props.yaml
+++ b/src/yaml/sfbt/rambuckel-horse-props.yaml
@@ -26,7 +26,7 @@ info:
   summary: Rambuckel Horse MMPs
   description: |
     This pack contains 28 different horses as Mayor Mode Ploppables (MMP). There are various grey, brown and black horses, ponies and foals available.
-    
+
     Click repeatedly with the left mouse button to select between the individual models. The last model of each plop cycle is "empty", this can be useful if you accidentially selected a wrong item and want to remove it again without using the bulldozer tool.
 
   author: rambuckel, FrankyFour, Andreas
@@ -50,7 +50,7 @@ info:
   summary: Rambuckel Horse Carriage MMPs
   description: |
     This pack contains various coaches as Mayor Mode Ploppables (MMP).:
-    
+
     -   **Ambulance:* These coaches were used for military and civil purposes until about the 1930s. The first coaches were built in the late 19th century when the first Samaritan associations like the Red Cross were founded.
     -   **Berline:** The Berline is a fully sprung travel coach which got its name from the fact that it was very popular in circles of the Brandenburg nobility in the 17th century.
     -   **Caleche:** A four-wheel carriage with a cabin and two seats. It’s quite a small coach, but still comfortable.

--- a/src/yaml/sfbt/rambuckel-horse-props.yaml
+++ b/src/yaml/sfbt/rambuckel-horse-props.yaml
@@ -73,4 +73,4 @@ assets:
 assetId: sfbt-rambuckel-horse-props
 version: "1"
 lastModified: "2023-08-17T18:13:36.000Z"
-url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=121:sfbt-props-rambuckel-horse-props&catid=22
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=121:sfbt-props-rambuckel-horse-props

--- a/src/yaml/sfbt/rambuckel-horse-props.yaml
+++ b/src/yaml/sfbt/rambuckel-horse-props.yaml
@@ -3,7 +3,7 @@ name: rambuckel-horse-props
 version: "1"
 subfolder: 100-props-textures
 info:
-  summary: Rambuckel Horse Props
+  summary: Horse Props by Rambuckel
   description: |
     This prop pack is the ultimate pack for everyone who loves horses. It contains more than 300 props with various horses, and a set of horse coaches. The horses (bay horses, grey horses and black horses) and coaches can be used in Lot Editor as props (grouped in various prop families).
   author: rambuckel, FrankyFour, Andreas
@@ -23,7 +23,7 @@ name: rambuckel-horse-mmps
 version: "1"
 subfolder: 180-flora
 info:
-  summary: Rambuckel Horse MMPs
+  summary: Horse MMPs by Rambuckel
   description: |
     This pack contains 28 different horses as Mayor Mode Ploppables (MMP). There are various grey, brown and black horses, ponies and foals available.
 
@@ -47,9 +47,9 @@ name: rambuckel-horse-carriage-mmps
 version: "1"
 subfolder: 180-flora
 info:
-  summary: Rambuckel Horse Carriage MMPs
+  summary: Horse Carriage MMPs by Rambuckel
   description: |
-    This pack contains various coaches as Mayor Mode Ploppables (MMP).:
+    This pack contains various coaches as Mayor Mode Ploppables (MMP):
 
     -   **Ambulance:* These coaches were used for military and civil purposes until about the 1930s. The first coaches were built in the late 19th century when the first Samaritan associations like the Red Cross were founded.
     -   **Berline:** The Berline is a fully sprung travel coach which got its name from the fact that it was very popular in circles of the Brandenburg nobility in the 17th century.

--- a/src/yaml/sfbt/royal-light-signal-props.yaml
+++ b/src/yaml/sfbt/royal-light-signal-props.yaml
@@ -20,4 +20,4 @@ assets:
 assetId: sfbt-royal-light-signal-props
 version: "1"
 lastModified: "2023-08-17T17:44:15.000Z"
-url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=119:sfbt-props-royal-light-signal-props&catid=22
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=119:sfbt-props-royal-light-signal-props

--- a/src/yaml/sfbt/royal-light-signal-props.yaml
+++ b/src/yaml/sfbt/royal-light-signal-props.yaml
@@ -5,8 +5,8 @@ subfolder: 100-props-textures
 info:
   summary: Royal Light Signal Props
   description: |
-    This prop pack contains a total number of 147 different light signals, both distant signals and main signals. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own.  
-     
+    This prop pack contains a total number of 147 different light signals, both distant signals and main signals. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own.
+
     In the Lot Editor, all signals are listed with the prefix "SFBT\_Bahn\_...", so they are neatly grouped for easier finding. Most of the props are available as orthogonal and diagonal version, both as centered prop ("zentriert nullpunkt") and rendered with an offset of 16 m ("+16", "-16"), which are intended to be used "besides" the actual lot , that can be placed next to the tracks.
 
   author: Royal

--- a/src/yaml/sfbt/royal-light-signal-props.yaml
+++ b/src/yaml/sfbt/royal-light-signal-props.yaml
@@ -1,0 +1,25 @@
+group: sfbt
+name: royal-light-signal-props
+version: "1"
+subfolder: 100-props-textures
+info:
+  summary: Royal Light Signal Props
+  description: |
+    This prop pack contains a total number of 147 different light signals, both distant signals and main signals. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own.  
+     
+    In the Lot Editor, all signals are listed with the prefix "SFBT\_Bahn\_...", so they are neatly grouped for easier finding. Most of the props are available as orthogonal and diagonal version, both as centered prop ("zentriert nullpunkt") and rendered with an offset of 16 m ("+16", "-16"), which are intended to be used "besides" the actual lot , that can be placed next to the tracks.
+
+  author: Royal
+  website: https://www.sc4evermore.com/index.php/downloads/download/119-sfbt-props-royal-light-signal-props
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/Lichtsignale_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/Lichtsignale_02.jpg
+
+assets:
+  - assetId: sfbt-royal-light-signal-props
+
+---
+assetId: sfbt-royal-light-signal-props
+version: "1"
+lastModified: "2023-08-17T17:44:15.000Z"
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=119:sfbt-props-royal-light-signal-props&catid=22

--- a/src/yaml/sfbt/royal-light-signal-props.yaml
+++ b/src/yaml/sfbt/royal-light-signal-props.yaml
@@ -3,11 +3,9 @@ name: royal-light-signal-props
 version: "1"
 subfolder: 100-props-textures
 info:
-  summary: Royal Light Signal Props
+  summary: Light Signal Props by Royal
   description: |
-    This prop pack contains a total number of 147 different light signals, both distant signals and main signals. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own.
-
-    In the Lot Editor, all signals are listed with the prefix "SFBT\_Bahn\_...", so they are neatly grouped for easier finding. Most of the props are available as orthogonal and diagonal version, both as centered prop ("zentriert nullpunkt") and rendered with an offset of 16 m ("+16", "-16"), which are intended to be used "besides" the actual lot , that can be placed next to the tracks.
+    This prop pack contains a total number of 147 different light signals, both distant signals and main signals. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lots or similar included.
 
   author: Royal
   website: https://www.sc4evermore.com/index.php/downloads/download/119-sfbt-props-royal-light-signal-props

--- a/src/yaml/sfbt/royal-semaphore-signals-props.yaml
+++ b/src/yaml/sfbt/royal-semaphore-signals-props.yaml
@@ -20,4 +20,4 @@ assets:
 assetId: sfbt-royal-semaphore-signals-props
 version: "1"
 lastModified: "2023-08-17T17:59:45.000Z"
-url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=120:sfbt-props-royal-semaphore-signals-props&catid=22
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=120:sfbt-props-royal-semaphore-signals-props

--- a/src/yaml/sfbt/royal-semaphore-signals-props.yaml
+++ b/src/yaml/sfbt/royal-semaphore-signals-props.yaml
@@ -5,8 +5,8 @@ subfolder: 100-props-textures
 info:
   summary: Royal Semaphore Signals Props
   description: |
-    This prop pack contains a total number of more than 100 different semaphore signals, both distant signals and main signals. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own.  
-     
+    This prop pack contains a total number of more than 100 different semaphore signals, both distant signals and main signals. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own.
+
     In the Lot Editor, all signals are listed with the prefix "SFBT\_Bahn\_...", so they are neatly grouped for easier finding. Most of the props are available as orthogonal and diagonal version, both as centered prop ("zentriert nullpunkt") and rendered with an offset of 16 m ("+16", "-16"), which are intended to be used "besides" the actual lot , that can be placed next to the tracks.
   author: Royal
   website: https://www.sc4evermore.com/index.php/downloads/download/120-sfbt-props-royal-semaphore-signals-props

--- a/src/yaml/sfbt/royal-semaphore-signals-props.yaml
+++ b/src/yaml/sfbt/royal-semaphore-signals-props.yaml
@@ -3,11 +3,10 @@ name: royal-semaphore-signals-props
 version: "1"
 subfolder: 100-props-textures
 info:
-  summary: Royal Semaphore Signals Props
+  summary: Semaphore Signals Props by Royal
   description: |
-    This prop pack contains a total number of more than 100 different semaphore signals, both distant signals and main signals. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own.
+    This prop pack contains a total number of more than 100 different semaphore signals, both distant signals and main signals. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lots or similar included.
 
-    In the Lot Editor, all signals are listed with the prefix "SFBT\_Bahn\_...", so they are neatly grouped for easier finding. Most of the props are available as orthogonal and diagonal version, both as centered prop ("zentriert nullpunkt") and rendered with an offset of 16 m ("+16", "-16"), which are intended to be used "besides" the actual lot , that can be placed next to the tracks.
   author: Royal
   website: https://www.sc4evermore.com/index.php/downloads/download/120-sfbt-props-royal-semaphore-signals-props
   images:

--- a/src/yaml/sfbt/royal-semaphore-signals-props.yaml
+++ b/src/yaml/sfbt/royal-semaphore-signals-props.yaml
@@ -1,0 +1,24 @@
+group: sfbt
+name: royal-semaphore-signals-props
+version: "1"
+subfolder: 100-props-textures
+info:
+  summary: Royal Semaphore Signals Props
+  description: |
+    This prop pack contains a total number of more than 100 different semaphore signals, both distant signals and main signals. The props are intended for usage on rail lots and mods for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own.  
+     
+    In the Lot Editor, all signals are listed with the prefix "SFBT\_Bahn\_...", so they are neatly grouped for easier finding. Most of the props are available as orthogonal and diagonal version, both as centered prop ("zentriert nullpunkt") and rendered with an offset of 16 m ("+16", "-16"), which are intended to be used "besides" the actual lot , that can be placed next to the tracks.
+  author: Royal
+  website: https://www.sc4evermore.com/index.php/downloads/download/120-sfbt-props-royal-semaphore-signals-props
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/Formsignale_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/Formsignale_02.jpg
+
+assets:
+  - assetId: sfbt-royal-semaphore-signals-props
+
+---
+assetId: sfbt-royal-semaphore-signals-props
+version: "1"
+lastModified: "2023-08-17T17:59:45.000Z"
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=120:sfbt-props-royal-semaphore-signals-props&catid=22

--- a/src/yaml/sfbt/sam-johnson-playground-props.yaml
+++ b/src/yaml/sfbt/sam-johnson-playground-props.yaml
@@ -6,7 +6,7 @@ info:
   summary: Sam Johnson Playground Props
   description: |
     This extensive set of playground props has been created by Sam Johnson for using on his Moscow pre-fab lots, but they can be used on any (preferrably R-§) residential lots and playgrounds. All props are available in prop families with different colors, so no lot looks the same. Most of them were modeled after real-life playgrounds in Eastern Europe.
-    
+
     This prop pack contains about 100 different playground props. The props are intended for usage on playgrounds and other residential lots for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own. In the Lot Editor, all props are listed with the prefix "SFBT\_Spielplatzprop\_...", so they are neatly grouped for easier finding. The props are grouped into families, since each prop is available in various colors.
   author: Sam Johnson
   website: https://www.sc4evermore.com/index.php/downloads/download/122-sfbt-props-sam-johnson-playground-props

--- a/src/yaml/sfbt/sam-johnson-playground-props.yaml
+++ b/src/yaml/sfbt/sam-johnson-playground-props.yaml
@@ -3,11 +3,9 @@ name: sam-johnson-playground-props
 version: "1"
 subfolder: 100-props-textures
 info:
-  summary: Sam Johnson Playground Props
+  summary: Playground Props by Sam Johnson
   description: |
-    This extensive set of playground props has been created by Sam Johnson for using on his Moscow pre-fab lots, but they can be used on any (preferrably R-§) residential lots and playgrounds. All props are available in prop families with different colors, so no lot looks the same. Most of them were modeled after real-life playgrounds in Eastern Europe.
-
-    This prop pack contains about 100 different playground props. The props are intended for usage on playgrounds and other residential lots for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own. In the Lot Editor, all props are listed with the prefix "SFBT\_Spielplatzprop\_...", so they are neatly grouped for easier finding. The props are grouped into families, since each prop is available in various colors.
+    This extensive set of playground props has been created by Sam Johnson for use on his Moscow pre-fab lots, but they can be used on any (preferrably R-§) residential lots and playgrounds. All props are available in prop families with different colors, so no lot looks the same. Most of them were modeled after real-life playgrounds in Eastern Europe.
   author: Sam Johnson
   website: https://www.sc4evermore.com/index.php/downloads/download/122-sfbt-props-sam-johnson-playground-props
   images:

--- a/src/yaml/sfbt/sam-johnson-playground-props.yaml
+++ b/src/yaml/sfbt/sam-johnson-playground-props.yaml
@@ -19,4 +19,4 @@ assets:
 assetId: sfbt-sam-johnson-playground-props
 version: "1"
 lastModified: "2023-08-17T18:19:43.000Z"
-url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=122:sfbt-props-sam-johnson-playground-props&catid=22
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=122:sfbt-props-sam-johnson-playground-props

--- a/src/yaml/sfbt/sam-johnson-playground-props.yaml
+++ b/src/yaml/sfbt/sam-johnson-playground-props.yaml
@@ -1,0 +1,24 @@
+group: sfbt
+name: sam-johnson-playground-props
+version: "1"
+subfolder: 100-props-textures
+info:
+  summary: Sam Johnson Playground Props
+  description: |
+    This extensive set of playground props has been created by Sam Johnson for using on his Moscow pre-fab lots, but they can be used on any (preferrably R-§) residential lots and playgrounds. All props are available in prop families with different colors, so no lot looks the same. Most of them were modeled after real-life playgrounds in Eastern Europe.
+    
+    This prop pack contains about 100 different playground props. The props are intended for usage on playgrounds and other residential lots for SimCity 4. The pack only serves as a dependency, there are no lot or similar included. If you like to see those props in your game, you will have to install corresponding lots, or create your own. In the Lot Editor, all props are listed with the prefix "SFBT\_Spielplatzprop\_...", so they are neatly grouped for easier finding. The props are grouped into families, since each prop is available in various colors.
+  author: Sam Johnson
+  website: https://www.sc4evermore.com/index.php/downloads/download/122-sfbt-props-sam-johnson-playground-props
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/Spielplatzprops_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/thumbnails/Spielplatzprops_02.jpg
+
+assets:
+  - assetId: sfbt-sam-johnson-playground-props
+
+---
+assetId: sfbt-sam-johnson-playground-props
+version: "1"
+lastModified: "2023-08-17T18:19:43.000Z"
+url: https://www.sc4evermore.com/index.php/downloads?task=download.send&id=122:sfbt-props-sam-johnson-playground-props&catid=22


### PR DESCRIPTION
This PR adds all [sfbt dependencies](https://www.sc4evermore.com/index.php/component/tags/tag/sfbt) from SC4Evermore that weren't available in the default sc4pac channel yet. Note that I also included the `sfbt:petercrysti-props`, which I also included in #42. I will remove it from #42 to have it nicely grouped in this PR.