### PR TITLE
Remove unneeded dependencies from residential collection

### DIFF
--- a/src/yaml/mattb325/residential-houses-collection.yaml
+++ b/src/yaml/mattb325/residential-houses-collection.yaml
@@ -83,7 +83,7 @@ dependencies:
 ---
 group: mattb325
 name: worthington
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Worthington
@@ -144,7 +144,7 @@ variants:
 ---
 group: mattb325
 name: wolsely-rd
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Wolsely Rd
@@ -174,7 +174,7 @@ variants:
 ---
 group: mattb325
 name: wilmore
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Wilmore
@@ -201,7 +201,7 @@ variants:
 ---
 group: mattb325
 name: westcliffe-xiii
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Westcliffe XIII
@@ -233,7 +233,7 @@ variants:
 ---
 group: mattb325
 name: wellington-i
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Wellington I
@@ -264,7 +264,7 @@ variants:
 ---
 group: mattb325
 name: timberline
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Timberline
@@ -294,7 +294,7 @@ variants:
 ---
 group: mattb325
 name: the-warren
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: The Warren
@@ -321,7 +321,7 @@ variants:
 ---
 group: mattb325
 name: texas
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Texas
@@ -350,7 +350,7 @@ variants:
 ---
 group: mattb325
 name: sterling-cape-cod
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Sterling Cape Cod
@@ -377,7 +377,7 @@ variants:
 ---
 group: mattb325
 name: southport-ii
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Southport II
@@ -408,7 +408,7 @@ variants:
 ---
 group: mattb325
 name: southport-mk1
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Southport MK1
@@ -437,7 +437,7 @@ variants:
 ---
 group: mattb325
 name: reussdale-house
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Reussdale House
@@ -496,7 +496,7 @@ variants:
 ---
 group: mattb325
 name: radcliffe
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Radcliffe
@@ -523,7 +523,7 @@ variants:
 ---
 group: mattb325
 name: prestondale
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Prestondale
@@ -554,7 +554,7 @@ variants:
 ---
 group: mattb325
 name: pomeroy
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Pomeroy
@@ -583,7 +583,7 @@ variants:
 ---
 group: mattb325
 name: northcote-st-haberfield
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Northcote St Haberfield
@@ -615,7 +615,7 @@ variants:
 ---
 group: mattb325
 name: newark
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Newark
@@ -672,7 +672,7 @@ variants:
 ---
 group: mattb325
 name: minnetonka
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Minnetonka
@@ -699,7 +699,7 @@ variants:
 ---
 group: mattb325
 name: mid-wealth-modern-homes
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Mid Wealth Modern Homes
@@ -732,7 +732,7 @@ variants:
 ---
 group: mattb325
 name: melrose
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Melrose
@@ -761,7 +761,7 @@ variants:
 ---
 group: mattb325
 name: low-wealth-modern-homes
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Low Wealth Modern Homes
@@ -820,7 +820,7 @@ variants:
 ---
 group: mattb325
 name: lakehouse
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Lakehouse
@@ -850,7 +850,7 @@ variants:
 ---
 group: mattb325
 name: la-salle
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: La Salle
@@ -879,7 +879,7 @@ variants:
 ---
 group: mattb325
 name: kiowa
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Kiowa
@@ -906,7 +906,7 @@ variants:
 ---
 group: mattb325
 name: kimberley
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Kimberley
@@ -933,7 +933,7 @@ variants:
 ---
 group: mattb325
 name: kendrick
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Kendrick
@@ -1029,7 +1029,7 @@ variants:
 ---
 group: mattb325
 name: hotondo-homes-alpha-237-series
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Hotondo Homes Alpha 237 Series
@@ -1065,7 +1065,7 @@ variants:
 ---
 group: mattb325
 name: hillsboro
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Hillsboro
@@ -1092,7 +1092,7 @@ variants:
 ---
 group: mattb325
 name: hickory
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Hickory
@@ -1120,7 +1120,7 @@ variants:
 ---
 group: mattb325
 name: glendale
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Glendale
@@ -1175,7 +1175,7 @@ variants:
 ---
 group: mattb325
 name: fitzsimmon
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Fitzsimmon
@@ -1232,7 +1232,7 @@ variants:
 ---
 group: mattb325
 name: english-revival-cottage
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: English Revival Cottage
@@ -1260,7 +1260,7 @@ variants:
 ---
 group: mattb325
 name: edith-st-mosman
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Edith St Mosman
@@ -1319,7 +1319,7 @@ variants:
 ---
 group: mattb325
 name: connecticut
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Connecticut
@@ -1372,7 +1372,7 @@ variants:
 ---
 group: mattb325
 name: castleton
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Castleton
@@ -1456,7 +1456,7 @@ variants:
 ---
 group: mattb325
 name: bristol
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Bristol
@@ -1487,7 +1487,7 @@ variants:
 ---
 group: mattb325
 name: biltwell-4235
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: BiltWell 4235
@@ -1516,7 +1516,7 @@ variants:
 ---
 group: mattb325
 name: biltwell-4224
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: BiltWell 4224
@@ -1543,7 +1543,7 @@ variants:
 ---
 group: mattb325
 name: biltwell-4205
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: BiltWell 4205
@@ -1570,7 +1570,7 @@ variants:
 ---
 group: mattb325
 name: belmont-rd
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Belmont Rd
@@ -1605,7 +1605,7 @@ variants:
 ---
 group: mattb325
 name: american-stick
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: American Stick

--- a/src/yaml/mattb325/residential-houses-collection.yaml
+++ b/src/yaml/mattb325/residential-houses-collection.yaml
@@ -97,7 +97,6 @@ dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -160,7 +159,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:textures-vol01
 variants:
   - variant: { nightmode: standard }
@@ -189,7 +187,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-jmyers-common-props
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -219,7 +216,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
   - bsc:textures-vol01
@@ -252,7 +248,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -283,7 +278,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -313,7 +307,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -343,8 +336,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-jmyers-common-props
-  - bsc:mega-props-misc-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -372,7 +363,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mjb-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -402,7 +392,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -432,7 +421,6 @@ dependencies:
   - bsc:bat-props-mattb325-mcmansion-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -465,7 +453,6 @@ dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -522,7 +509,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -552,7 +538,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -584,7 +569,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mjb-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -615,7 +599,6 @@ dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -647,7 +630,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-jmyers-common-props
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -703,9 +685,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-jmyers-common-props
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -736,9 +715,6 @@ dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
   - bsc:textures-vol02
@@ -771,7 +747,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mjb-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -801,8 +776,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol03
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -861,7 +834,6 @@ dependencies:
   - bsc:mega-props-cp-vol02
   - bsc:mega-props-jrj-vol04
   - bsc:mega-props-jrj-vol05
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -893,7 +865,6 @@ dependencies:
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
   - bsc:mega-props-misc-vol01
-  - bsc:mega-props-rt-vol02
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -921,8 +892,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -950,8 +919,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-jmyers-common-props
-  - bsc:mega-props-misc-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -982,7 +949,6 @@ dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -1083,7 +1049,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol03
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -1113,7 +1078,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1142,10 +1106,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-jmyers-common-props
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
-  - bsc:mega-props-misc-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1174,7 +1134,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:prop-family-names
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1231,7 +1190,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -1287,9 +1245,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-jmyers-common-props
-  - bsc:mega-props-misc-vol01
-  - bsc:mega-props-rt-vol02
   - bsc:textures-vol01
 variants:
   - variant: { nightmode: standard }
@@ -1321,7 +1276,6 @@ dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -1380,9 +1334,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
-  - bsc:mega-props-rt-vol02
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1434,7 +1385,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1521,7 +1471,6 @@ dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -1553,8 +1502,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-jmyers-common-props
-  - bsc:mega-props-misc-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1582,7 +1529,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1610,7 +1556,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1644,9 +1589,6 @@ dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
-  - bsc:mega-props-misc-vol01
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -1676,8 +1618,6 @@ dependencies:
   - bsc:bat-props-mattb325-cottages-ornee-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-jmyers-common-props
-  - bsc:mega-props-misc-vol01
 variants:
   - variant: { nightmode: standard }
     assets:

--- a/src/yaml/mattb325/residential-multi-unit-collection.yaml
+++ b/src/yaml/mattb325/residential-multi-unit-collection.yaml
@@ -103,7 +103,7 @@ variants:
 ---
 group: mattb325
 name: waterloo-apartments
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Waterloo Apartments
@@ -174,7 +174,7 @@ variants:
 ---
 group: mattb325
 name: vivo-apartments
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Vivo Apartments
@@ -271,7 +271,7 @@ variants:
 ---
 group: mattb325
 name: small-apartments
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Small Apartments
@@ -470,7 +470,7 @@ variants:
 ---
 group: mattb325
 name: modern-townhouses
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Modern Townhouses
@@ -528,7 +528,7 @@ variants:
 ---
 group: mattb325
 name: l-aquila-apartments
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: L'Aquila Apartments
@@ -592,7 +592,7 @@ variants:
 ---
 group: mattb325
 name: lennox-gardens
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Lennox Gardens
@@ -620,7 +620,7 @@ variants:
 ---
 group: mattb325
 name: lansdowne-terrace
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Lansdowne Terrace
@@ -865,7 +865,7 @@ variants:
 ---
 group: mattb325
 name: ennuyeuse-apartments
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Ennuyeuse Apartments
@@ -931,7 +931,7 @@ variants:
 ---
 group: mattb325
 name: emporio-apartments
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Emporio Apartments
@@ -960,7 +960,7 @@ variants:
 ---
 group: mattb325
 name: embassy-apartments
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Embassy Apartments
@@ -1054,7 +1054,7 @@ variants:
 ---
 group: mattb325
 name: cube-apartments
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Cube Apartments
@@ -1122,7 +1122,7 @@ variants:
 ---
 group: mattb325
 name: commons-court
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Commons Court
@@ -1210,7 +1210,7 @@ variants:
 ---
 group: mattb325
 name: boom-style-terraces
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Boom Style Terraces
@@ -1268,7 +1268,7 @@ variants:
 ---
 group: mattb325
 name: beurlay-apartments
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Beurlay Apartments
@@ -1307,7 +1307,7 @@ variants:
 ---
 group: mattb325
 name: bayauxlaan-apartments
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Bayauxlaan Apartments
@@ -1438,7 +1438,7 @@ variants:
 ---
 group: mattb325
 name: alhambra-duplex
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Alhambra Duplex
@@ -1472,7 +1472,7 @@ variants:
 ---
 group: mattb325
 name: ainslee-condos
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Ainslee Condos
@@ -1506,7 +1506,7 @@ variants:
 ---
 group: mattb325
 name: casa-de-manana
-version: "1.2"
+version: "1.2-1"
 subfolder: 200-residential
 info:
   summary: Casa de Manana

--- a/src/yaml/mattb325/residential-multi-unit-collection.yaml
+++ b/src/yaml/mattb325/residential-multi-unit-collection.yaml
@@ -123,8 +123,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol03
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
   - bsc:texturepack-cycledogg-vol01
 variants:
   - variant: { nightmode: standard }
@@ -192,8 +190,6 @@ info:
 
 dependencies:
   - bsc:essentials
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -287,9 +283,6 @@ dependencies:
   - bsc:essentials
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
-  - bsc:mega-props-newmaninc-vol04
   - bsc:textures-vol01
 variants:
   - variant: { nightmode: standard }
@@ -492,8 +485,6 @@ info:
 
 dependencies:
   - bsc:essentials
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -556,11 +547,6 @@ dependencies:
   - bsc:essentials
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
-  - bsc:mega-props-misc-vol01
-  - bsc:mega-props-mjb-vol01
-  - bsc:mega-props-newmaninc-vol04
   - bsc:textures-vol01
   - bsc:textures-vol03
 variants:
@@ -619,7 +605,6 @@ dependencies:
   - bsc:bat-props-mattb325-london-w2w-vol01
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-gascooker-vol01
-  - bsc:mega-props-rt-vol02
   - porkissimo:jenx-porkie-expanded-porkie-props
 variants:
   - variant: { nightmode: standard }
@@ -647,7 +632,6 @@ dependencies:
   - bsc:essentials
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-gascooker-vol01
-  - bsc:mega-props-mjb-vol01
   - bsc:mega-props-sg-vol01
   - porkissimo:jenx-porkie-expanded-porkie-props
 variants:
@@ -898,8 +882,6 @@ dependencies:
   - bsc:essentials
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
   - bsc:texturepack-cycledogg-vol01
 variants:
   - variant: { nightmode: standard }
@@ -962,9 +944,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
-  - bsc:mega-props-newmaninc-vol04
   - bsc:mega-props-sg-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
@@ -994,10 +973,7 @@ dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
   - bsc:mega-props-misc-vol02
-  - bsc:mega-props-newmaninc-vol04
   - bsc:texturepack-cycledogg-vol01
 variants:
   - variant: { nightmode: standard }
@@ -1097,8 +1073,6 @@ dependencies:
   - bsc:essentials
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1166,10 +1140,6 @@ info:
 dependencies:
   - bsc:essentials
   - bsc:bat-props-mattb325-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
-  - bsc:mega-props-newmaninc-vol04
-  - bsc:mega-props-rt-vol02
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1252,7 +1222,6 @@ dependencies:
   - bsc:essentials
   - bsc:bat-props-mattb325-vol01
   - bsc:bat-props-mattb325-vol04
-  - bsc:mega-props-rt-vol02
   - bsc:mega-props-sg-vol01
   - porkissimo:jenx-porkie-expanded-porkie-props
 variants:
@@ -1323,8 +1292,6 @@ dependencies:
   - bsc:essentials
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
   - bsc:texturepack-cycledogg-vol01
 variants:
   - variant: { nightmode: standard }
@@ -1359,8 +1326,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol03
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
   - bsc:texturepack-cycledogg-vol01
 variants:
   - variant: { nightmode: standard }
@@ -1492,7 +1457,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol03
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol01
   - bsc:texturepack-cycledogg-vol01
 variants:
   - variant: { nightmode: standard }
@@ -1527,8 +1491,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
   - bsc:texturepack-cycledogg-vol01
 variants:
   - variant: { nightmode: standard }
@@ -1564,9 +1526,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-mikeseith-vol01
-  - bsc:mega-props-mikeseith-vol03
-  - bsc:mega-props-newmaninc-vol04
   - bsc:texturepack-cycledogg-vol01
 variants:
   - variant: { nightmode: standard, mattb325:casa-de-manana:climate: temperate }


### PR DESCRIPTION
Following up on #43, this PR removes a bunch of dependencies from #41. They were previously included because certain packages from the bsc common dependencies pack add props to existent Maxis families, which caused them to be tracked, while not actually being a hard dependency.