### PR TITLE
Add various dependencies

### DIFF
--- a/src/yaml/agc/casual-sims-dlc.yaml
+++ b/src/yaml/agc/casual-sims-dlc.yaml
@@ -1,0 +1,44 @@
+group: agc
+name: casual-sims-dlc
+version: "1.0.0"
+subfolder: 180-flora
+info:
+  summary: Casual Sims DLC
+  description: |-
+    This DLC contain 60 sims, and provides them as MMP's.
+
+    Note: if you use the props on your lots, please specify `pkg=agc:casual-sims-dlc-props` as a dependency rather than this one.
+  author: Barroco Hispano
+  website: https://community.simtropolis.com/files/file/35560-agc-casual-sims-dlc/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2023_06/649d7b0d8cb06_image(1).png.a50b033afacff103b8d00d725981b1af.png
+dependencies:
+  - agc:casual-sims-dlc-props
+assets:
+  - assetId: agc-casual-sims-dlc
+    include:
+      - .dat$
+
+---
+group: agc
+name: casual-sims-dlc-props
+version: "1.0.0"
+subfolder: 100-props-textures
+info:
+  summary: Casual Sims DLC Props
+  description: |-
+    This package is a resource package for `pkg=agc:casual-sims-dlc` and contains all the models & prop exemplars.
+    Specify this one as a dependency if you use them on your lots instead of `pkg=agc:casual-sims-dlc`.
+  author: Barroco Hispano
+  website: https://community.simtropolis.com/files/file/35560-agc-casual-sims-dlc/
+assets:
+  - assetId: agc-casual-sims-dlc
+    include:
+      - .SC4Desc$
+      - .SC4Model$
+
+---
+assetId: agc-casual-sims-dlc
+version: "1.0.0"
+lastModified: "2023-06-29T12:42:35Z"
+url: https://community.simtropolis.com/files/file/35560-agc-casual-sims-dlc/?do=download&r=197307

--- a/src/yaml/agc/environment-dlc.yaml
+++ b/src/yaml/agc/environment-dlc.yaml
@@ -1,0 +1,44 @@
+group: agc
+name: environment-dlc
+version: "5.0.0"
+subfolder: 180-flora
+info:
+  summary: Environment DLC
+  description: |-
+    This package contains trees, plants, rocks, ponds and other things related to the environment, and provides them as MMP's.
+
+    Note: if you use the props on your lots, please specify `pkg=agc:environment-dlc-props` as a dependency rather than this one, as this one will add a lot of items to your MMP menu, which is not desirable if you're only using the props as a dependency!
+  author: Barroco Hispano
+  website: https://community.simtropolis.com/files/file/34720-agc-environment-dlc/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2021_10/ENVIRONMENT_ICON.png.9ef96068a94834cce519aed06c392fb8.png
+dependencies:
+  - agc:environment-dlc-props
+assets:
+  - assetId: agc-environment-dlc
+    include:
+      - .dat$
+
+---
+group: agc
+name: environment-dlc-props
+version: "5.0.0"
+subfolder: 100-props-textures
+info:
+  summary: Environment DLC Props
+  description: |-
+    This package is a resource package for `pkg=agc:environment-dlc` and contains all the models & prop exemplars.
+    Specify this one as a dependency if you use them on your lots instead of `pkg=agc:environment-dlc`.
+  author: Barroco Hispano
+  website: https://community.simtropolis.com/files/file/34720-agc-environment-dlc/
+assets:
+  - assetId: agc-environment-dlc
+    include:
+      - .SC4Desc$
+      - .SC4Model$
+
+---
+assetId: agc-environment-dlc
+version: "5.0.0"
+lastModified: "2023-06-10T16:10:48Z"
+url: https://community.simtropolis.com/files/file/34720-agc-environment-dlc/?do=download&r=197215

--- a/src/yaml/r6/prop-pack-2010-vol1.yaml
+++ b/src/yaml/r6/prop-pack-2010-vol1.yaml
@@ -1,0 +1,16 @@
+group: r6
+name: prop-pack-2010-vol1
+version: "1"
+subfolder: 100-props-textures
+assets:
+  - assetId: r6-prop-pack-2010-vol1
+info:
+  summary: Prop Pack 2010 Vol 01
+  author: r6
+  website: https://www.toutsimcities.com/downloads/view/1686
+
+---
+assetId: r6-prop-pack-2010-vol1
+version: "1"
+lastModified: "2010-04-18T12:00:00Z"
+url: https://www.toutsimcities.com/downloads/start/1686

--- a/src/yaml/r6/prop-pack-2010-vol2.yaml
+++ b/src/yaml/r6/prop-pack-2010-vol2.yaml
@@ -1,0 +1,16 @@
+group: r6
+name: prop-pack-2010-vol2
+version: "1"
+subfolder: 100-props-textures
+assets:
+  - assetId: r6-prop-pack-2010-vol2
+info:
+  summary: Prop Pack 2010 Vol 02
+  author: r6
+  website: https://www.toutsimcities.com/downloads/view/1702
+
+---
+assetId: r6-prop-pack-2010-vol2
+version: "1"
+lastModified: "2010-05-06T12:00:00Z"
+url: https://www.toutsimcities.com/downloads/start/1702

--- a/src/yaml/r6/prop-pack-vol1.yaml
+++ b/src/yaml/r6/prop-pack-vol1.yaml
@@ -1,0 +1,16 @@
+group: r6
+name: prop-pack-vol1
+version: "2"
+subfolder: 100-props-textures
+assets:
+  - assetId: r6-prop-pack-vol1
+info:
+  summary: Prop Pack Vol 01
+  author: r6
+  website: https://www.toutsimcities.com/downloads/view/1584
+
+---
+assetId: r6-prop-pack-vol1
+version: "2"
+lastModified: "2009-09-09T12:00:00Z"
+url: https://www.toutsimcities.com/downloads/start/1584

--- a/src/yaml/r6/prop-pack-vol2.yaml
+++ b/src/yaml/r6/prop-pack-vol2.yaml
@@ -1,0 +1,16 @@
+group: r6
+name: prop-pack-vol2
+version: "1"
+subfolder: 100-props-textures
+assets:
+  - assetId: r6-prop-pack-vol2
+info:
+  summary: Prop Pack Vol 02
+  author: r6
+  website: https://www.toutsimcities.com/downloads/view/1592
+
+---
+assetId: r6-prop-pack-vol2
+version: "1"
+lastModified: "2009-09-19T12:00:00Z"
+url: https://www.toutsimcities.com/downloads/start/1592


### PR DESCRIPTION
This PR adds a few dependencies that I encountered in https://github.com/sebamarynissen/simtropolis-channel/pull/52, which I feel belong in the default channel.

Note that I've chosen to split up Barroco Hispano's packages in resources packages and mmp packages. That's because the `agc:environment-dlc` package pollutes the MMP menu quite a bit, so I feel like it should be possible to specify the props as a dependency without polluting your MMP menu.