### PR TITLE
Add images & update dependencies for commercial collection

### DIFF
--- a/src/yaml/mattb325/commercial-collection.yaml
+++ b/src/yaml/mattb325/commercial-collection.yaml
@@ -148,6 +148,12 @@ info:
     - https://community.simtropolis.com/files/file/30976-american-city-bank/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/AmericanCityBank.jpg.a2f0e7bb75f7c6a660c077df6865348e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/AmericanCityBank1.jpg.233d7a8a497059d8a39318aea4cdc893.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/AmericanCityBank2.jpg.f1bdb975c871a243d466c2231e843ca2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/AmericanCityBank3.jpg.6321b8096b5105dfa6632a923e160a4c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/AmericanCityBank4.jpg.553e077aef6a6952daab8efb3cc0e13e.jpg
 dependencies:
   - bsc:mega-props-cp-vol02
 variants:
@@ -200,6 +206,12 @@ info:
     - https://community.simtropolis.com/files/file/32992-ashland-ave/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_06/FoodCourt.jpg.9f26db5bd3e9a288cc4dd363950341e8.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_06/FoodCourt1.jpg.49d6d1cc81d1139b4fe5ba4b012d154b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_06/FoodCourt2.jpg.8cdbb8b30a8ba484e41cd634752c9276.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_06/FoodCourt3.jpg.d5d0bbea95e319f1df8b175b61a99b20.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_06/FoodCourt4.jpg.7e5a8f5b5eb23a5a08a1ca7a7c018480.jpg
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -252,6 +264,13 @@ info:
     - https://community.simtropolis.com/files/file/33110-bauhaus-mannheim/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Bauhaus.jpg.8a641028de9e15ba7a1118477361986f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Bauhaus1.jpg.ccdf6f6a1ea24ce17789bb544f6c32c4.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Bauhaus2.jpg.3458cd4128224b7b2b9fb7526482bd38.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Bauhaus3.jpg.0f84eacda54764671163e495f3a0d4e5.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Bauhaus4.jpg.a0d2aa588d33ce09b5fb2922f4fa71c6.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Bauhaus5.jpg.608e655d4a4eae4b7bdae733552315ee.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
 variants:
@@ -279,6 +298,12 @@ info:
     - https://community.simtropolis.com/files/file/33132-bonzai-building/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/Bonzai.jpg.09d05e2a2f9104c14bd8f94bbd79e558.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/Bonzai1.jpg.8b5814fb2905f2e24815161f9ba342a8.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/Bonzai2.jpg.b3f78cfda658413498f802586238cfdd.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/Bonzai3.jpg.2daa332a9e10af7e955775c40a196729.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/Bonzai4.jpg.4402f39b347febc2531deeb560d1bdb2.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol03
   - bsc:textures-vol01
@@ -410,6 +435,11 @@ info:
     - https://community.simtropolis.com/files/file/28120-chez-mondo/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/4c60e6d044bc60dd043c4a888c97d15e-chezmondo.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/5bac577149fb192dbae878414f7cb537-chezmondo1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/8049a78a14d4111eb28ad22911ed05a9-chezmondo11.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/e8228add53f82a8f6fb15303a396c678-chezmondo2.jpg
 dependencies:
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
@@ -440,6 +470,14 @@ info:
     - https://community.simtropolis.com/files/file/33038-ciros-nightclub/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Ciros.jpg.2bffbba35d93a1a300e653809391680b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Ciros1.jpg.adf6be4e0fa569aab8412db3a7bdcb59.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Ciros2.jpg.c4fff14fc33bad3eb4b137e9155b1731.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Ciros3.jpg.c475e1e2bf87b87038f61b2b5b52f128.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Ciros4.jpg.a5e10511f9b70ff1086ecd4485dd9e72.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Ciros5.jpg.885a1264bd3ad14ef2c1ad792f96bfad.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Ciros6.jpg.c2c9c948c7a65756cffec661e0ed7216.jpg
 dependencies:
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
@@ -527,6 +565,12 @@ info:
     - https://community.simtropolis.com/files/file/33109-columbia-savings-bank/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/ColumbiaSavings.jpg.2b898dcf59d0954015fb16a73fdd89b8.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/ColumbiaSavings1.jpg.47e65be2f14bf721ff57de234d733844.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/ColumbiaSavings2.jpg.00e5c8840ac5900dc2917aa9623cd411.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/ColumbiaSavings3.jpg.79535144097e568e0b4c06bcdcd3bcf5.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/ColumbiaSavings4.jpg.3af215ea16a6345955121250e28c3973.jpg
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -579,6 +623,11 @@ info:
     - https://community.simtropolis.com/files/file/33031-crosstown-hotel/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Crosstown.jpg.5fecc66d4629d1d158a0af924d72ac75.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Crosstown1.jpg.0d2abadcd7f2af7cd5da376a6eefa7af.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Crosstown2.jpg.d5c50b7e5afe9a1c1c56834bd71d42a0.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Crosstown3.jpg.1e3c88176f0a98197cf6c50e2ba19df1.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:textures-vol01
@@ -687,6 +736,13 @@ info:
     - https://community.simtropolis.com/files/file/33032-downtown-hotel/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Downtown.jpg.d24b6cef62cdff77808dc3871b402093.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Downtown1.jpg.ca8599a4605aa6144a54c674017c72be.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Downtown2.jpg.076ac1cde94ea624a9d65710bf9ba877.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Downtown3.jpg.0fdf9878571b647b162da9b00d1e1ea3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Downtown4.jpg.73fef281cac4b170ea9e8d507ddbdbae.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Downtown5.jpg.9ae82d46d0d079b044c0fff33f0de56d.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03
@@ -770,6 +826,11 @@ info:
     - https://community.simtropolis.com/files/file/31627-europa-house/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/Europa.jpg.8b9c4994cd4a58069208d6745f803349.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/Europa1.jpg.f44a9e144f56f268fb4244bbe07344b4.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/Europa2.jpg.9be17af5b1ff26e4d66718af8f2f6533.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/Europa3.jpg.c3b514516c40f16ec170f3b1f5dc101d.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
 variants:
@@ -797,6 +858,18 @@ info:
     - https://community.simtropolis.com/files/file/31629-first-federal-bank/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/FirstFederal.jpg.3e37e301ca65b7fe0d2c4c1889030800.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/FirstFederal_PostCard.jpg.f1a0f246fb1289bcd08aa84ffd2d517d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/FirstFederal1.jpg.3403a09056298c9c83daaced23ca274c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/FirstFederal2.jpg.37558c49e671d86dff8bfe45f82de747.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/FirstFederal3.jpg.959bcf29bd2c73c7779c07b4bb684094.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/FirstFederal4.jpg.08277ed8f456d911b5fb30bd892bafc0.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/FirstFederal5.jpg.8b4e9ee231bb1411f6d9864ae792b7e8.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/FirstFederal6.jpg.ad11cb2858020fe163d3764efc4aacf1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/FirstFederal7.jpg.92acad06d508fd25c6487461f02b4d3c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/FirstFederalPostCard1.jpg.75d7b9d8a78acd461a6f5ec9121360d7.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/FirtsFederal8.jpg.e71a207baed97350d3345baf70aae397.jpg
 dependencies:
   - bsc:mega-props-cp-vol02
 variants:
@@ -851,6 +924,12 @@ info:
     - https://community.simtropolis.com/files/file/30923-golden-state-insurance/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2016_01/GoldenState_sn1.jpg.9f4c0e447126b29459136dc30ed191c3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_01/GoldenState_Sn2.jpg.889815bd75580ac7244ab3211ff4f06b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_01/GoldenState_Sn3.jpg.0f52840e3a170e6bd54b49630549cf9e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_01/GoldenState_sn.jpg.24639c724c6df1e5dbdd50141744087d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_01/GoldenState_n.jpg.5056f3bba09d40cb5831fe7b7b744189.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
 variants:
@@ -956,6 +1035,13 @@ info:
     - https://community.simtropolis.com/files/file/31736-harrods/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Harrods.jpg.d9a5dc9f9a3bdcca1c7d05687493dc2e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Harrods1.jpg.cd87ff24024d58e50158649ecd3ad874.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Harrods2.jpg.7fa934eac0d4827b2f570a13bb81cabe.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Harrods3.jpg.90509a7bff0b86cee2ec52972beecf53.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Harrods4.jpg.b0294cf017ea1f0323623d6107685439.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Harrods5.jpg.af3d2772fa3b8b0b1e3ea709ded54f75.jpg
 dependencies:
   - bsc:mega-props-misc-vol02
   - maxis:dlc-props
@@ -1007,6 +1093,14 @@ info:
     - https://community.simtropolis.com/files/file/33947-hungry-jacks/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/HungryJacks.jpg.7ae342b0516dc214ecb493359c942161.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/HungryJacks1.jpg.c5a673657a84da979edf69536a331630.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/HungryJacks2.jpg.fafc5a507619373145ccf4bcdfe6df34.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/HungryJacks3.jpg.7e2b7eebd2c763b779e42fe8217715cc.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/HungryJacks4.jpg.5f99d79faa745bf6f5f23d6e742f7d4b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/HungryJacks5.jpg.24cb904989ceb5142721b7d9ef9440f1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/HungryJacks6.jpg.fbad8d6a704c8869ff276595607cdeb1.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
@@ -1037,6 +1131,13 @@ info:
     - https://community.simtropolis.com/files/file/31833-ing-direct/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/ING.jpg.8b23fee14a2632d735dfe33a829c056b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/ING_N.jpg.2f1513e2194503eb3acb5e9be8618221.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/ING1.jpg.b260a82a8768300401fef5ec73c12901.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/ING2.jpg.dc7b3fc53ca1e8e34bad49fa67efae50.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/ING3.jpg.5e5580d8650870067b327ddaf4a4ad3f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/ING4.jpg.49d8431a0081517e833f4abbdc0e4bd6.jpg
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1173,6 +1274,16 @@ info:
     - https://community.simtropolis.com/files/file/33188-mcdonalds/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/McDonalds.jpg.82d8e26a68315d0de0b56d94aa56a531.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/McDonalds0.jpg.ab7e00826f8edc08e42a134c63292067.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/McDonalds1.jpg.37735babbaaec51fc0215047f26db12d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/McDonalds2.jpg.0cd4660ad0c002da631be04af52edd62.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/McDonalds3.jpg.ab133cb46840e038262d3c5ec24c2659.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/McDonalds4.jpg.7aa0fb2ba08b40014722d19ae96036cd.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/McDonalds5.jpg.21f73ed21556f791884c0cfd67359e8c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/McDonalds6.jpg.c1c646ec9f507b9c0dde6df47a7f074b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/McDonalds7.jpg.33e3b47090885889ff6575230045baa2.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-misc-vol02
@@ -1202,6 +1313,13 @@ info:
     - https://community.simtropolis.com/files/file/31744-millennium-hotel-knightsbridge/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Millennium.jpg.d2dfb70ed5fdbb4c34a8bffc8268ac41.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Millennium1.jpg.91cac86ed9cdaa4e9542b11390f3dda9.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Millennium2.jpg.371dccfaea40901ae45609e0ec874c8e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Millennium3.jpg.a22e77e4804df6fb469f97da517ee095.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Millennium4.jpg.636a4568de244684ef9c17f78ffdf810.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_06/Millennium5.jpg.40efd666fffc8373486c0c1a0f549fa4.jpg
 dependencies:
   - bsc:mega-props-misc-vol02
 variants:
@@ -1229,6 +1347,13 @@ info:
     - https://community.simtropolis.com/files/file/30873-mini-cooper-dealership/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/MiniCooper.jpg.7b474029b3a9a04c7f7cf15ec0f54271.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/MiniCooper1.jpg.d0f08ef79ceda6f13bf0571eef6d9f59.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/MiniCooper2.jpg.46a42b686e453fffbbb15cdb539829ae.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/MiniCooper3.jpg.4b9df6db8c99df1c484bbf69f369feef.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/MiniCooper4.jpg.975ab8785117bf47006e496f045418b8.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/MiniCooper5.jpg.dca5acd6c0df3a3d41c4818c79e788af.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03
@@ -1357,6 +1482,11 @@ info:
     - https://community.simtropolis.com/files/file/33010-niche-moderne/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/NicheModerne.jpg.f2867d493e91c39f9ed3ee5f151881b5.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/NicheModerne1.jpg.2d441b1df58d5cb5e05fdefbd07cc4f4.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/NicheModerne2.jpg.7de2a39d19f22f14fc13e7a9212b4792.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/NicheModerne3.jpg.05ae9f42882c88e9c6f39335ba7b7ee2.jpg
 dependencies:
   - bsc:mega-props-cp-vol02
 variants:
@@ -1569,6 +1699,12 @@ info:
     - https://community.simtropolis.com/files/file/31645-quay-house/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/QuayHouse.jpg.137cae39ac6934cb0e22a5617aa65e1e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/QuayHouse1.jpg.d08781cfd9c2f2c974c54cda49a1891e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/QuayHouse2.jpg.fc27c0add402f91f093b84c670937233.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/QuayHouse3.jpg.c0d9f9f0bb095054d1de54b8272f20f3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_05/QuayHouse4.jpg.0bfe0568fe3d93379a2df260e9463edc.jpg
 dependencies:
   - bsc:mega-props-cp-vol02
   - mattb325:commercial-collection-shared-resources
@@ -1622,6 +1758,12 @@ info:
     - https://community.simtropolis.com/files/file/33131-retro-tower/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/105-sc4d-lex-legacy-mattb325-commercial-w2w-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/Polaroid.jpg.9d7c6ea991d87b7e027dadf707eb1b04.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/Polaroid1.jpg.4024260910871c979298e0b8dd646e70.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/Polaroid2.jpg.8e4cfab2b5dea8dd487fe2b5b0278b58.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/Polaroid3.jpg.5ff70c0d8b907d8bf6a6077bc38711ed.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/Polaroid4.jpg.244b46824806213967b6616a5c3c880a.jpg
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1751,6 +1893,15 @@ info:
     - https://community.simtropolis.com/files/file/31839-standard-federal-savings-and-loan/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/StandardFederal.jpg.d6766f3361df33330642f54d99c96b6b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/StandardFederal1.jpg.4def11e188461e430f9affcb0d21e1ba.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/StandardFederal2.jpg.451989acec484faa694a1bafab309dd2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/StandardFederal3.jpg.f02308c2933ffbde5948e09fbaa71964.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/StandardFederal4.jpg.4c04aad9c141f5a434202519ce3706e5.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/StandardFederal5.jpg.cb86f79aaab53ca70b6a6a8258dcadb2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/StandardFederal6.jpg.a477a6e79cbeaa89fd16755b4d274269.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2017_07/StandardFederal7.jpg.287b138dfc7b5abdf8cfe94be481d7c2.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol03
 variants:
@@ -1778,6 +1929,10 @@ info:
     - https://community.simtropolis.com/files/file/30959-teville-square/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/Teville.jpg.78940316e56a95b6827d3ea308112290.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/Teville1.jpg.6fa333b00d9680c8fb2bea3283727916.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/Teville2.jpg.e364a54f49849714414dafa7a7179667.jpg
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1803,6 +1958,12 @@ info:
     - https://community.simtropolis.com/files/file/30986-the-bon-marche/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2016_03/TheBonMarche.jpg.bb7c37c8103130755cca9f3daddba4fc.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_03/TheBonMarche1.jpg.02175d5827c1ded3ccfd9b557e9e6b0c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_03/TheBonMarche2.jpg.ef4f36efd9a43616434fe38aea274393.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_03/TheBonMarche3.jpg.9008016e5f03cec8350081b7050a2c07.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_03/TheBonMarche4.jpg.66724c07b79ea8b003067d3db59f8f04.jpg
 dependencies:
   - bsc:mega-props-misc-vol02
   - bsc:textures-vol01
@@ -1884,6 +2045,21 @@ info:
     - https://community.simtropolis.com/files/file/30974-uk-retailers-pack-dark-nite/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail.jpg.9893d7fa7bffd54f8bc04a48c33f2c92.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail1.jpg.89302675c5c854adecf5a85b7b73c89e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail2.jpg.3bf18d57e52ce9c10fa3daee2511f72e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail3.jpg.1d348ae2bac15764b6f3138ba49e5225.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail4.jpg.ac69c46f9bca845637f7118e2dded652.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail5.jpg.1f677fcc0e03a3b27f5e4888c1c6908f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail6.jpg.cc8273a89bb3be19ab2c41741731ec14.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail7.jpg.9d35bc3819720587bff89d1b771bc187.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail8.jpg.1f9fe6c2ddb9eb6fbd946f193310884a.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail5.jpg.fa7491ee80c4df331ec2cb84ee480d3b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail6.jpg.44bb5c52d65b9971ab3fbae26e8b89d4.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail7.jpg.0b40014a28e6a6c5ead7df47b491afd8.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail8.jpg.30c3ca2fb5cb80519a1a25cacc771759.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail9.jpg.e62a40742ff00acfe64002cd473d4970.jpg
 dependencies:
   - bsc:mega-props-cp-vol02
   - bsc:mega-props-misc-vol02
@@ -1912,6 +2088,12 @@ info:
     - https://community.simtropolis.com/files/file/28488-united-central-bank/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_02_2013/8cc996c75a6c088455d0d726d4a4d470-ucb.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2013/eca42df6e8065294ee517179b788820d-ucb1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2013/8a0fdb886bcdfae53e76a1b21f00aae7-ucb2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2013/79c22ebce858630d53a7e2eda0c3ac45-ucb4.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2013/65a5d0eddc5327e4be480ebe0a54edee-ucb5.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol03
 variants:

--- a/src/yaml/mattb325/commercial-collection.yaml
+++ b/src/yaml/mattb325/commercial-collection.yaml
@@ -503,7 +503,6 @@ info:
 dependencies:
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - csx:mega-props-vol06
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -530,7 +529,6 @@ info:
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
 dependencies:
-  - bsc:mega-props-misc-vol02
   - mattb325:commercial-collection-shared-resources
 variants:
   - variant: { nightmode: standard }
@@ -563,7 +561,6 @@ dependencies:
   - bsc:mega-props-swi21-vol01
   - bsc:textures-vol01
   - bsc:textures-vol02
-  - csx:mega-props-vol06
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -621,7 +618,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol02
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -768,7 +764,6 @@ info:
 dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03
-  - bsc:mega-props-misc-vol02
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1065,7 +1060,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2017_06/Harrods4.jpg.b0294cf017ea1f0323623d6107685439.jpg
     - https://www.simtropolis.com/objects/screens/monthly_2017_06/Harrods5.jpg.af3d2772fa3b8b0b1e3ea709ded54f75.jpg
 dependencies:
-  - bsc:mega-props-misc-vol02
   - maxis:dlc-props
 variants:
   - variant: { nightmode: standard }
@@ -1126,7 +1120,6 @@ info:
 dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-cp-vol01
-  - bsc:mega-props-misc-vol02
   - supershk:mega-parking-textures
 variants:
   - variant: { nightmode: standard }
@@ -1268,8 +1261,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol04
   - bsc:mega-props-d66-vol01
   - bsc:mega-props-jes-vol01
-  - bsc:mega-props-misc-vol01
-  - bsc:mega-props-misc-vol02
   - bsc:mega-props-sg-vol01
   - bsc:textures-vol02
   - csx:mega-props-vol04
@@ -1308,7 +1299,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2019_09/McDonalds7.jpg.33e3b47090885889ff6575230045baa2.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol04
-  - bsc:mega-props-misc-vol02
   - supershk:mega-parking-textures
 variants:
   - variant: { nightmode: standard }
@@ -1343,7 +1333,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2017_06/Millennium4.jpg.636a4568de244684ef9c17f78ffdf810.jpg
     - https://www.simtropolis.com/objects/screens/monthly_2017_06/Millennium5.jpg.40efd666fffc8373486c0c1a0f549fa4.jpg
 dependencies:
-  - bsc:mega-props-misc-vol02
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1665,7 +1654,6 @@ dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol02
   - bsc:mega-props-sg-vol01
   - bsc:textures-vol01
 variants:
@@ -1694,7 +1682,6 @@ dependencies:
   - bsc:bat-props-mattb325-shopping-mall-pack-vol01
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-cp-vol01
-  - bsc:mega-props-misc-vol02
   - bsc:mega-props-sg-vol01
   - bsc:textures-vol01
   - maxis:dlc-props
@@ -1987,7 +1974,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_03/TheBonMarche3.jpg.9008016e5f03cec8350081b7050a2c07.jpg
     - https://www.simtropolis.com/objects/screens/monthly_2016_03/TheBonMarche4.jpg.66724c07b79ea8b003067d3db59f8f04.jpg
 dependencies:
-  - bsc:mega-props-misc-vol02
   - bsc:textures-vol01
 variants:
   - variant: { nightmode: standard }
@@ -2084,7 +2070,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_02/UK_Retail9.jpg.e62a40742ff00acfe64002cd473d4970.jpg
 dependencies:
   - bsc:mega-props-cp-vol02
-  - bsc:mega-props-misc-vol02
   - bsc:mega-props-sg-vol01
   - bsc:textures-vol01
 variants:

--- a/src/yaml/mattb325/commercial-collection.yaml
+++ b/src/yaml/mattb325/commercial-collection.yaml
@@ -1332,7 +1332,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2017_06/Millennium3.jpg.a22e77e4804df6fb469f97da517ee095.jpg
     - https://www.simtropolis.com/objects/screens/monthly_2017_06/Millennium4.jpg.636a4568de244684ef9c17f78ffdf810.jpg
     - https://www.simtropolis.com/objects/screens/monthly_2017_06/Millennium5.jpg.40efd666fffc8373486c0c1a0f549fa4.jpg
-dependencies:
 variants:
   - variant: { nightmode: standard }
     assets:

--- a/src/yaml/mattb325/commercial-collection.yaml
+++ b/src/yaml/mattb325/commercial-collection.yaml
@@ -21,6 +21,15 @@ info:
     - https://community.simtropolis.com/files/file/33144-100-king-st-manchester/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/100KingSt.jpg.af5b801fbde2dd59936f80af29f5987f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/100KingSt1.jpg.4b22b626c062e24bce0a3ce437cacd78.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/100KingSt2.jpg.351077775864ba32e67f6c2a977fb6be.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/100KingSt3.jpg.8e1aa99112f147dc73670f8ac535d090.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/100KingSt4.jpg.aba845c29412f41e2efa7c43d36b5877.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/100KingSt5.jpg.d3e6160dd07fafbeb17f7630678e76e3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/100KingSt6.jpg.d134f049af9a08f2020c0cb75ab2a72a.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_09/100KingSt7.jpg.407f23ace888bb7ff2bd67150b567c71.jpg
 dependencies:
   - mattb325:commercial-collection-shared-resources
 variants:
@@ -72,6 +81,12 @@ info:
     - https://community.simtropolis.com/files/file/33893-45-east-avenue-rochester-ny/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/45EastAveRochester.jpg.9e2ee4bbbbd079982e1fc979ce389391.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/45EastAveRochester1.jpg.1bc6efd4a82d972b5561ba7b8e74edd7.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/45EastAveRochester2.jpg.ab5067ea19a9952d85fc961b175c5afa.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/45EastAveRochester3.jpg.f57eb7eb9e98690cfe6ced40787a6996.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/45EastAveRochester4.jpg.61997635a2782f5de205a98b2c83c36a.jpg
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -95,6 +110,13 @@ info:
     - https://community.simtropolis.com/files/file/33899-85-elizabeth-st-sydney/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/Atanaskovic.jpg.dde1f8db6c32be11218d036e862bc9c3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/Atanaskovic1.jpg.783f9fb9e1f66183729e873b87d85397.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/Atanaskovic2.jpg.df63f73912c0158eefc5e279d5282dbe.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/Atanaskovic3.jpg.58c5ecc3aea743417047e94ee8d3b9bf.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/Atanaskovic4.jpg.02ebd82f4e1d195f766ca060b4f7dd2d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/Atanaskovic5.jpg.63c86fb11c32bbae688e2ad36df45a2f.jpg
 dependencies:
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
@@ -2147,6 +2169,12 @@ info:
     - https://community.simtropolis.com/files/file/28683-zurich-insurance/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_05_2013/2c72f637a667de5fbdc746d2c98e3011-zurich.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_05_2013/30b09270fd2ed3f8cd04c0e102162ad4-zurich1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_05_2013/3f5bf2cdd1e2adf3e36aaf4999f987e6-zurich2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_05_2013/d1e7d048c7a15b835ae3aa9f14471d24-zurich3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_05_2013/e930fb25f0a82186ceb0b5f416a46acb-zurich4.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03

--- a/src/yaml/mattb325/commercial-collection.yaml
+++ b/src/yaml/mattb325/commercial-collection.yaml
@@ -144,6 +144,13 @@ info:
     - https://community.simtropolis.com/files/file/30886-2404-wilshire-blvd/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/AmericanCement.jpg.914bc8130a32224b11b55093b671db93.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/AmericanCement1.jpg.f7f09ef9f75d5ea8d9426bfb8ffdfc7a.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/AmericanCement2.jpg.8bb6046c894017a2b570fdf37f8c98d5.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/AmericanCement3.jpg.64e8d73a8858c7d58de81359d9b75183.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/AmericanCement4.jpg.a748c8c055b8f8dfdf8be88df1e81d27.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/AmericanCement5.jpg.6d04be1e929fe639ddd14ad5ceecad45.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03
@@ -259,6 +266,14 @@ info:
     - https://community.simtropolis.com/files/file/30871-modern-audi-dealership/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Audi.jpg.ba961e5235d624df04de8bd29e9e5b47.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Audi1.jpg.c6244ff3a6066a181ff5d381ac6179dd.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Audi2.jpg.9d98e3ba36aac09db03c4069cd9168ae.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Audi3.jpg.2690df5d7eec845d962f936e1e493314.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Audi4.jpg.f838f55c6eb21c3cd7cd9419d43a9903.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Audi5.jpg.a8b075e28dbde41e68848cf98aeae824.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Audi6.jpg.1fa766af513edb41f9cf808e5cc9ded8.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03
@@ -355,7 +370,14 @@ info:
     - https://community.simtropolis.com/files/file/33041-bullocks-department-store/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Bullocks.jpg.5fb50043308c3d02ffb0c3e3a87d09e6.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Bullocks1.jpg.df1844f0842e9757f6919f6f23aeb66e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Bullocks2.jpg.4aa6873ff2a5a8ccb862f1ccbd1d503f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Bullocks3.jpg.118ec990d18302863a4e974a2eb5b132.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Bullocks4.jpg.42d8768527ba3ca93b5218c6e6b12444.jpg
 dependencies:
+  - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
   - shk:parking-pack
@@ -431,6 +453,10 @@ info:
     - https://community.simtropolis.com/files/file/30866-chevrolet-dealership/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Chevrolet.jpg.286f5e5286d6020c03a2ef9f87e16900.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Chevrolet1.jpg.7eb2fa87f7b9deb5ac8921237cd26585.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Chevrolet2.jpg.5dfeabfb54914295e55990d546e793ce.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-cp-vol02
@@ -728,6 +754,12 @@ info:
     - https://community.simtropolis.com/files/file/33033-debenhams-department-store/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Debenhams.jpg.00227702806b40890147fc1981b02792.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Debenhams1.jpg.9214d694a0331e058401a526d4d673c9.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Debenhams2.jpg.b5e21e85f0deb3913259c6765091a52c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Debenhams3.jpg.91292541c334e26a13facd84768ab077.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/Debenhams4.jpg.3544f5a6b25f39c12b8e71fec2325009.jpg
 dependencies:
   - bsc:mega-props-cp-vol02
   - porkissimo:jenx-porkie-expanded-porkie-props
@@ -1027,6 +1059,11 @@ info:
     - https://community.simtropolis.com/files/file/33067-harlequin-building-london/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Harlequin.jpg.11e4e6795c0d785c5f8513bcfdee261c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Harlequin1.jpg.1ec705902c6257d20929d7e0ad6d5729.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Harlequin2.jpg.7a69360ebe70459bdaff836aa1d96b65.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Harlequin3.jpg.2d88c82ca8441c1c95ac71556d208bce.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol03
 variants:
@@ -1086,6 +1123,13 @@ info:
     - https://community.simtropolis.com/files/file/33019-hua-seng-enterprises-inc/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/HuaSeng.jpg.279dbf47d441900223ca0698b391c6f2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/HuaSeng1.jpg.98c6dffa8a4621f0be1493d2cc8b2399.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/HuaSeng2.jpg.3c95fb1ad67c55a1f1ffa879e304c03e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/HuaSeng3.jpg.6eee7fc5f7e6a4b20681785e2331a990.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/HuaSeng4.jpg.e47f45496c01623edf31a771f0ce80e2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/HuaSeng5.jpg.2aa33c130c3c785d1e2bb504e6f91d40.jpg
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1178,6 +1222,11 @@ info:
     - https://community.simtropolis.com/files/file/30865-car-yard-by-mattb325/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Kia.jpg.1d905ae4fc2ba5909e6faa565e114c75.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Kia1.jpg.4383380c27b05226b1981e841cf2e62c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Kia2.jpg.117c0938337f0cf7f2d0588f1578b79a.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/Kia3.jpg.923cb362860b8a1f484f041c766e4308.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-cp-vol01
@@ -1205,6 +1254,12 @@ info:
     - https://community.simtropolis.com/files/file/33125-kyneton-square/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Kyneton.jpg.9034641e4d785dd13574754da223bd84.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Kyneton1.jpg.db86170daaa577f1d3ea048204526024.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Kyneton2.jpg.15157d3a163022d2cfd3973cefce4732.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Kyneton3.jpg.9434037114bcbf22da63705fef6286ad.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Kyneton4.jpg.ea6d61e4d2f4e744be4e1cecec3f1ffb.jpg
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -1225,8 +1280,14 @@ info:
   summary: Luxury Auto Yard
   author: mattb325
   websites:
+    - https://community.simtropolis.com/files/file/27998-luxury-car-dealership/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_09_2012/2aa39640550696b611cce19606bcd5e9-caryard.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_09_2012/16b4a5b9cf7741efada88f9ee58fd677-caryard1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_09_2012/27435b9740b0b6328bb0383c1f316318-caryard2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_09_2012/16c496f8be41ab8f717a7f9be94d7a9f-caryard3.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-cp-vol01
@@ -1597,6 +1658,7 @@ info:
   author: mattb325
   websites:
     - https://community.simtropolis.com/files/file/33952-pwn-london/
+    - https://community.simtropolis.com/files/file/32993-pwn-london/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
 dependencies:
@@ -1624,6 +1686,12 @@ info:
     - https://community.simtropolis.com/files/file/33018-pinyin-enterprises-pty-ltd/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/PinYin.jpg.36dbe6444618154453096fd5a526d1df.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/PinYin1.jpg.72c0cde752758e7812fe5ed76c957ca6.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/PinYin2.jpg.b9702bba87396e411f49c2d7654da07c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/PinYin3.jpg.e9059439a6c7fa80d3be86e66c0cfa4b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/PinYin4.jpg.08b00804949f9c9c79a2c6aa2004004e.jpg
 dependencies:
   - mattb325:urban-civics-prop-pack-vol01
 variants:
@@ -1797,6 +1865,13 @@ info:
     - https://community.simtropolis.com/files/file/30881-sac-commercial/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/SAC.jpg.74b9b658c291dbbbba759f020868db0f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/SAC1.jpg.3078c9d2dd03ddffae4a3ac6e3b9d097.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/SAC2.jpg.26b644ae243caa2db32e2c0eeac9a933.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/SAC3.jpg.a27d3f486e3688f787ee19a067a01498.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/SAC4.jpg.604d1ab6384e187728e33f76f777356c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2015_12/SAC5.jpg.3531b16f3523ffe3d2498057a00356e1.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
 variants:
@@ -1875,6 +1950,13 @@ info:
     - https://community.simtropolis.com/files/file/33873-saks-fifth-avenue/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/SAKS_LA.jpg.8956cf56d75d282d09e58f09d5f98475.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/SAKS_LA1.jpg.567b1cbe1c74400ec6b834c419e7ef5c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/SAKS_LA2.jpg.288b808fafe5a46ea9a316e88733b2af.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/SAKS_LA3.jpg.9c444bafabefb0d83c06b1a7f52b2731.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/SAKS_LA4.jpg.9e8d813555f3acb81fddcc30be22d93b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/SAKS_LA5.jpg.fd8552af271cf4f893e1628cff656823.jpg
 dependencies:
   - bsc:mega-props-cp-vol02
   - shk:parking-pack
@@ -1999,6 +2081,11 @@ info:
     - https://community.simtropolis.com/files/file/33037-transport-indemnity-insurance-building/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/103-sc4d-lex-legacy-mattb325-commercial-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/102-sc4d-lex-legacy-mattb325-commercial-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/FARrrail.jpg.e55d299958ed288df789236ed60be7ea.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/FARrrail1_lg.jpg.2592856f6e6e3ac5e452f3d43025f4c2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/FARrrail2_lg.jpg.7679459d552d597550f7587cd968d3f6.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/FARrrail3_lg.jpg.b2b9cfe4548506d8a144faf6905b9998.jpg
 variants:
   - variant: { nightmode: standard }
     assets:

--- a/src/yaml/mattb325/commercial-w2w-collection.yaml
+++ b/src/yaml/mattb325/commercial-w2w-collection.yaml
@@ -122,6 +122,12 @@ info:
     - https://community.simtropolis.com/files/file/28161-miller-street-offices/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/105-sc4d-lex-legacy-mattb325-commercial-w2w-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/104-sc4d-lex-legacy-mattb325-commercial-w2w-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/9f4cedafa7459cca585d6f97f2532779-miller.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/82c6697ba5b0bf17bd508818ac27dd6a-miller1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/a08f7af45c2623afa4be4ab1758c84ad-miller2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/566c061a02e09695f37ea29596ab47d7-miller3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/88fd29bcde5171d570ba69ae8f79df57-miller4.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:bat-props-mattb325-vol03
@@ -808,6 +814,12 @@ info:
     - https://community.simtropolis.com/files/file/33874-pirie-st-adelaide/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/105-sc4d-lex-legacy-mattb325-commercial-w2w-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/104-sc4d-lex-legacy-mattb325-commercial-w2w-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/Pirie_St.jpg.d945ade15056bef38a9ac57c8690d5f9.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/Pirie_St1.jpg.c26990a198ff41ad12735a2014aa12e5.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/Pirie_St2.jpg.a10ad054ee1eb5102402afa879bdf413.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/Pirie_St3.jpg.cd5df842859c4688683968be4d21726a.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/Pirie_St4.jpg.99d82c98e8226f3618ccb17e7b2bea3e.jpg
 variants:
   - variant: { nightmode: standard }
     assets:

--- a/src/yaml/mattb325/commercial-w2w-collection.yaml
+++ b/src/yaml/mattb325/commercial-w2w-collection.yaml
@@ -99,7 +99,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_02_2013/2da6dac81c4d1d16a26720f8b2c669c2-wilshire2.jpg
     - https://www.simtropolis.com/objects/screens/monthly_02_2013/a86c2fe2895a43a3b61c76d811885c1e-wilshire3.jpg
     - https://www.simtropolis.com/objects/screens/monthly_02_2013/7c7a0f17296dbb798ef4683e768d87c7-wilshire4.jpg
-dependencies:
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -684,7 +683,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2020_10/KingSt2.jpg.465c41662ef5af823f2297232609cb54.jpg
     - https://www.simtropolis.com/objects/screens/monthly_2020_10/KingSt3.jpg.2b1eb1b7f9a8deccad3d673af4f2ba72.jpg
     - https://www.simtropolis.com/objects/screens/monthly_2020_10/KingSt4.jpg.3c473894be35ce769760d90c680551d6.jpg
-dependencies:
 variants:
   - variant: { nightmode: standard }
     assets:

--- a/src/yaml/mattb325/commercial-w2w-collection.yaml
+++ b/src/yaml/mattb325/commercial-w2w-collection.yaml
@@ -44,7 +44,6 @@ info:
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/104-sc4d-lex-legacy-mattb325-commercial-w2w-pack-darknite
 dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
-  - bsc:mega-props-misc-vol02
   - porkissimo:jenx-porkie-expanded-porkie-props
 variants:
   - variant: { nightmode: standard }
@@ -101,7 +100,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_02_2013/a86c2fe2895a43a3b61c76d811885c1e-wilshire3.jpg
     - https://www.simtropolis.com/objects/screens/monthly_02_2013/7c7a0f17296dbb798ef4683e768d87c7-wilshire4.jpg
 dependencies:
-  - bsc:mega-props-misc-vol02
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -333,8 +331,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_10_2012/7dd43c40edcf49da7b94804d60ae85f8-coopershall3.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
-  - bsc:mega-props-misc-vol02
-  - csx:mega-props-vol06
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -461,7 +457,6 @@ info:
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/104-sc4d-lex-legacy-mattb325-commercial-w2w-pack-darknite
 dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
-  - bsc:mega-props-misc-vol02
   - porkissimo:jenx-porkie-expanded-porkie-props
 variants:
   - variant: { nightmode: standard }
@@ -690,7 +685,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2020_10/KingSt3.jpg.2b1eb1b7f9a8deccad3d673af4f2ba72.jpg
     - https://www.simtropolis.com/objects/screens/monthly_2020_10/KingSt4.jpg.3c473894be35ce769760d90c680551d6.jpg
 dependencies:
-  - bsc:mega-props-misc-vol02
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -740,7 +734,6 @@ info:
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/104-sc4d-lex-legacy-mattb325-commercial-w2w-pack-darknite
 dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
-  - bsc:mega-props-misc-vol02
   - porkissimo:jenx-porkie-expanded-porkie-props
 variants:
   - variant: { nightmode: standard }
@@ -1017,7 +1010,6 @@ info:
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/104-sc4d-lex-legacy-mattb325-commercial-w2w-pack-darknite
 dependencies:
   - bsc:bat-props-mattb325-w2w-prop-pack-vol01
-  - bsc:mega-props-misc-vol02
   - porkissimo:jenx-porkie-expanded-porkie-props
 variants:
   - variant: { nightmode: standard }

--- a/src/yaml/mattb325/commercial-w2w-collection.yaml
+++ b/src/yaml/mattb325/commercial-w2w-collection.yaml
@@ -94,6 +94,12 @@ info:
     - https://community.simtropolis.com/files/file/28505-5657-wilshire-blvd/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/105-sc4d-lex-legacy-mattb325-commercial-w2w-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/104-sc4d-lex-legacy-mattb325-commercial-w2w-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_02_2013/a694f69fbc7a9d91a40f1187fde44738-wilshire.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2013/e767a69e017eed0ab304bdef3cbfddfa-wilshire1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2013/2da6dac81c4d1d16a26720f8b2c669c2-wilshire2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2013/a86c2fe2895a43a3b61c76d811885c1e-wilshire3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2013/7c7a0f17296dbb798ef4683e768d87c7-wilshire4.jpg
 dependencies:
   - bsc:mega-props-misc-vol02
 variants:
@@ -145,6 +151,11 @@ info:
     - https://community.simtropolis.com/files/file/33126-amestoy-building/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/105-sc4d-lex-legacy-mattb325-commercial-w2w-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/104-sc4d-lex-legacy-mattb325-commercial-w2w-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Amestoy.jpg.6cbad28f67846dd1b864865f0456f9c9.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Amestoy1.jpg.34080b92d3e4916231574eb63821e775.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Amestoy2.jpg.84d53adf040c429e575bc8d0582732fe.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_08/Amestoy3.jpg.17b476940ce8ce054c1c7b4fff01b8c5.jpg
 variants:
   - variant: { nightmode: standard }
     assets:
@@ -315,6 +326,11 @@ info:
     - https://community.simtropolis.com/files/file/28144-coopers-hall/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/105-sc4d-lex-legacy-mattb325-commercial-w2w-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/104-sc4d-lex-legacy-mattb325-commercial-w2w-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/fa3024855a823a5b0db49f07e78bcd48-coopershall.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/3d7e8c4d517e42d35a178554bca4bfb9-coopershall1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/a91bb2911608e6bb15f1c449dec029e4-coopershall2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_10_2012/7dd43c40edcf49da7b94804d60ae85f8-coopershall3.jpg
 dependencies:
   - bsc:bat-props-mattb325-vol02
   - bsc:mega-props-misc-vol02
@@ -667,6 +683,12 @@ info:
     - https://community.simtropolis.com/files/file/33914-king-st-sydney/
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/105-sc4d-lex-legacy-mattb325-commercial-w2w-pack-maxisnite
     - https://www.sc4evermore.com/index.php/downloads/download/12-commercial/104-sc4d-lex-legacy-mattb325-commercial-w2w-pack-darknite
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/KingSt.jpg.b21f122fac04925254a07ba8904821ae.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/KingSt1.jpg.b3a9cc2b9e4e977e6be36716fd546eda.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/KingSt2.jpg.465c41662ef5af823f2297232609cb54.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/KingSt3.jpg.2b1eb1b7f9a8deccad3d673af4f2ba72.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_10/KingSt4.jpg.3c473894be35ce769760d90c680551d6.jpg
 dependencies:
   - bsc:mega-props-misc-vol02
 variants:

--- a/src/yaml/mattb325/new-york-w2w.yaml
+++ b/src/yaml/mattb325/new-york-w2w.yaml
@@ -12,7 +12,9 @@ info:
     Some of the buildings not only grow as Commercial, but also as Residential buildings.
     They grow on lot sizes 1×1, 1×2 and 2×2 for medium and high-density zones with the New York tileset.
   author: "mattb325"
-  website: https://community.simtropolis.com/files/file/33079-new-york-w2w-pack-vol01-maxis-nite-version/
+  websites:
+    - https://community.simtropolis.com/files/file/33079-new-york-w2w-pack-vol01-maxis-nite-version/
+    - https://community.simtropolis.com/files/file/33078-new-york-w2w-pack-vol01-darknite-version/
   images:
     - https://www.simtropolis.com/objects/screens/monthly_2019_08/NYC.jpg.5a1b4ceb470f11df7b6f1c0eab107f46.jpg
     - https://www.simtropolis.com/objects/screens/monthly_2019_08/NYC1.jpg.07c4381c56de62d2c2927af78f5e4307.jpg

--- a/src/yaml/mattb325/transportation-collection.yaml
+++ b/src/yaml/mattb325/transportation-collection.yaml
@@ -1407,8 +1407,19 @@ info:
   summary: Diagonal GLR Station
   author: mattb325
   websites:
+    - https://community.simtropolis.com/files/file/33006-diagonal-rail-glr-bus-and-subway-stations/
     - https://www.sc4evermore.com/index.php/downloads/download/19-transportation/315-sc4d-lex-legacy-mattb325-transportation-collection-darknite
     - https://www.sc4evermore.com/index.php/downloads/download/19-transportation/316-sc4d-lex-legacy-mattb325-transportation-collection-maxisnight
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/DiagonalRail3a.jpg.6d0c7544a5a0aff24fb60b5e1e06f090.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/DiagonalRail3.jpg.b77e9db9e42e97afe48d7c896ad8d5ef.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/DiagonalRail4.jpg.e5b7481bd58ac7b46b4e0bf25a125456.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/DiagonalRail5.jpg.e2260245115c44d36f55c8e5c46bdb4a.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/DiagonalRail6.jpg.cecd5b7a35a73b53907d597b8369d6c3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/DiagonalRail7.jpg.a0279edfe307ba2e2be31a16d9182b05.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/DiagonalRail.jpg.ce1e5b6f2c34eb4852d751df58d07e0f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/DiagonalRail8.jpg.51bbbe67703f456cc38583eca437b15b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_07/DiagonalRail9.jpg.a206af1d74f6c98135d5cc0251e03152.jpg
 dependencies:
   - mattb325:overhanging-multifunction-stations
 variants:

--- a/src/yaml/mattb325/transportation-collection.yaml
+++ b/src/yaml/mattb325/transportation-collection.yaml
@@ -1098,6 +1098,12 @@ info:
   websites:
     - https://www.sc4evermore.com/index.php/downloads/download/19-transportation/315-sc4d-lex-legacy-mattb325-transportation-collection-darknite
     - https://www.sc4evermore.com/index.php/downloads/download/19-transportation/316-sc4d-lex-legacy-mattb325-transportation-collection-maxisnight
+    - https://community.simtropolis.com/files/file/33950-far-3-rail-and-subway-station/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/FARrrail.jpg.e55d299958ed288df789236ed60be7ea.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/FARrrail1_lg.jpg.2592856f6e6e3ac5e452f3d43025f4c2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/FARrrail2_lg.jpg.7679459d552d597550f7587cd968d3f6.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2020_11/FARrrail3_lg.jpg.b2b9cfe4548506d8a144faf6905b9998.jpg
 dependencies:
   - mattb325:overhanging-multifunction-stations
 variants:

--- a/src/yaml/porkissimo/jenx-porkie-expanded-porkie-props.yaml
+++ b/src/yaml/porkissimo/jenx-porkie-expanded-porkie-props.yaml
@@ -14,7 +14,9 @@ info:
     2. `PorkieProps-Vol2.dat`
     3. `JENXPARIS_Tweaked_PorkieProps-Vol1.dat`
   author: "Porkissimo; Xannepan"
-  website: "https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/10-jenxporkie-expanded-porkie-props"
+  websites:
+    - "https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/10-jenxporkie-expanded-porkie-props"
+    - https://community.simtropolis.com/files/file/11421-jenx-porkie-expanded-porkie-props/
 
 ---
 assetId: "jenx-porkie-expanded-porkie-props"


### PR DESCRIPTION
This PR polishes `mattb325:commercial-collection` and `mattb325:commercial-w2w-collection` a bit by adding Simtropolis images where possible, and removing certain unneeded dependencies. The dependencies removed are

```
bsc:mega-props-misc-vol01
bsc:mega-props-misc-vol02
csx:mega-props-vol06
```

The problem is that those packages override certain Maxis props, and hence they got tracked by the dependency tracker. However, removing these packages reports no missing dependencies, so it's better to leave them out as they are not hard dependencies as such.

I'm not sure what to do with these cases in my dependency tracking code. I guess I could add a check whether a prop overrides something from the core Maxis files and then exclude this from the list of dependencies if that's the case. What's your opinion, @memo33 ?