### PR TITLE
Add ST link to `buddybud:concrete-wall-addon-stairs-resources`

### DIFF
--- a/src/yaml/buddybud/concrete-wall-addon-stairs.yaml
+++ b/src/yaml/buddybud/concrete-wall-addon-stairs.yaml
@@ -26,6 +26,7 @@ subfolder: 100-props-textures
 info:
   summary: Textures and props for Jeronij's Modern Concrete Walls
   author: Buddybud, Jeronij
+  website: https://community.simtropolis.com/files/file/13866-jeronij-concrete-wall-addon-stairs/
 assets:
   - assetId: buddybud-jrj-concrete-wall-addon-stairs
     include:


### PR DESCRIPTION
I quickly ran a script for packages that don't have at least 1 website set yet. The result was

```
memo:essential-fixes
buddybud:concrete-wall-addon-stairs-resources
mattb325:industrial-pack-shared-resources
mattb325:commercial-w2w-collection-shared-resources
mattb325:commercial-collection-shared-resources
fordoniak:wies-pack
```

From those, I think only `buddybud:concrete-wall-addon-stairs-resources` needs a website set.