### PR TITLE
introduce marker package `config:sc4-edition` to enforce version constraints

### DIFF
--- a/src/yaml/config/sc4-edition.yaml
+++ b/src/yaml/config/sc4-edition.yaml
@@ -1,0 +1,85 @@
+packages:
+- group: config
+  name: sc4-edition
+  version: "1"
+  subfolder: 060-config
+  variants:
+  - variant: { config:sc4-edition:edition: "Windows-digital" }
+    dependencies: [ config:sc4-edition-windows-digital ]
+  - variant: { config:sc4-edition:edition: "Windows-disc" }
+    dependencies: [ config:sc4-edition-windows-disc ]
+  - variant: { config:sc4-edition:edition: "macOS" }
+    dependencies: [ config:sc4-edition-macos ]
+
+  variantInfo:
+  - variantId: config:sc4-edition:edition
+    description: |-
+      Select the _SimCity 4 Deluxe_ edition for which you are installing plugins.
+
+      This is mainly used to determine if selected plugins are compatible with your edition of the game.
+      For example, DLL mods [cannot be used](https://community.simtropolis.com/forums/topic/762980-the-future-of-sc4-modding-the-matter-of-digital-vs-disc-and-windows-vs-macos-in-the-dll-era/) with the macOS edition, but often require the Windows digital edition.
+    values:
+    - value: "Windows-digital"
+      description: |-
+        The Windows digital edition (GOG, Steam, EA App), version `1.1.641`.
+    - value: "Windows-disc"
+      description: |-
+        The original disc edition.
+        Make sure the game is fully patched to version `1.1.640` by applying the [official patches](https://community.simtropolis.com/sc4-maxis-files/).
+        Older versions are not supported.
+    - value: "macOS"
+      description: |-
+        The Aspyr macOS port on Steam or on the Mac App Store.
+
+  info:
+    summary: Select the edition of your game
+    description: &desc This is a meta-package which does not install anything, but is used for defining incompatibilities.
+    website: &forum https://community.simtropolis.com/forums/topic/762980-the-future-of-sc4-modding-the-matter-of-digital-vs-disc-and-windows-vs-macos-in-the-dll-era/
+
+# ---
+- group: config
+  name: sc4-edition-windows-digital
+  version: "1.1.641"
+  subfolder: 060-config
+  dependencies:
+  - config:sc4-edition
+  conflicting:
+  - config:sc4-edition-windows-disc
+  - config:sc4-edition-macos
+
+  info:
+    summary: The Windows digital edition
+    description: *desc
+    website: *forum
+
+# ---
+- group: config
+  name: sc4-edition-windows-disc
+  version: "1.1.638"
+  subfolder: 060-config
+  dependencies:
+  - config:sc4-edition
+  conflicting:
+  - config:sc4-edition-windows-digital
+  - config:sc4-edition-macos
+
+  info:
+    summary: The disc edition for Windows
+    description: *desc
+    website: *forum
+
+# ---
+- group: config
+  name: sc4-edition-macos
+  version: "1.1.610"
+  subfolder: 060-config
+  dependencies:
+  - config:sc4-edition
+  conflicting:
+  - config:sc4-edition-windows-digital
+  - config:sc4-edition-windows-disc
+
+  info:
+    summary: The macOS port on Steam or the Mac App Store
+    description: *desc
+    website: *forum

--- a/src/yaml/memo/3d-camera-dll.yaml
+++ b/src/yaml/memo/3d-camera-dll.yaml
@@ -1,7 +1,9 @@
 group: "memo"
 name: "3d-camera-dll"
-version: "1.0.0-1"
+version: "1.0.0-2"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "memo-3d-camera-dll"
   withChecksum:

--- a/src/yaml/memo/region-thumbnail-fix-dll.yaml
+++ b/src/yaml/memo/region-thumbnail-fix-dll.yaml
@@ -1,7 +1,9 @@
 group: "memo"
 name: "region-thumbnail-fix-dll"
-version: "1.0.0-1"
+version: "1.0.0-2"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "memo-region-thumbnail-fix-dll"
   withChecksum:

--- a/src/yaml/memo/submenus-dll.yaml
+++ b/src/yaml/memo/submenus-dll.yaml
@@ -1,9 +1,10 @@
 group: "memo"
 name: "submenus-dll"
-version: "1.1.5"
+version: "1.1.5-1"
 subfolder: "150-mods"
 dependencies:
 - "null-45:sc4-resource-loading-hooks"
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "memo-submenus-dll"
   withChecksum:

--- a/src/yaml/memo/transparent-texture-fix-dll.yaml
+++ b/src/yaml/memo/transparent-texture-fix-dll.yaml
@@ -1,7 +1,9 @@
 group: "memo"
 name: "transparent-texture-fix-dll"
-version: "1.0.0-1"
+version: "1.0.0-2"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "memo-transparent-texture-fix-dll"
   withChecksum:

--- a/src/yaml/null-45/allow-more-building-styles.yaml
+++ b/src/yaml/null-45/allow-more-building-styles.yaml
@@ -1,7 +1,9 @@
 group: "null-45"
 name: "allow-more-building-styles-dll"
-version: "3.6.0"
+version: "3.6.0-1"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "null-45-allow-more-building-styles"
   withChecksum:

--- a/src/yaml/null-45/custom-budget-departments.yaml
+++ b/src/yaml/null-45/custom-budget-departments.yaml
@@ -1,7 +1,9 @@
 group: "null-45"
 name: "custom-budget-departments-dll"
-version: "1.0"
+version: "1.0-1"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "null-45-custom-budget-departments"
   withChecksum:

--- a/src/yaml/null-45/custom-ordinance-exemplar-host.yaml
+++ b/src/yaml/null-45/custom-ordinance-exemplar-host.yaml
@@ -1,7 +1,9 @@
 group: "null-45"
 name: "custom-ordinance-exemplar-host-dll"
-version: "1.0.1"
+version: "1.0.1-1"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "null-45-custom-ordinance-exemplar-host"
   exclude:

--- a/src/yaml/null-45/data-view-extensions.yaml
+++ b/src/yaml/null-45/data-view-extensions.yaml
@@ -1,7 +1,9 @@
 group: "null-45"
 name: "data-view-extensions-dll"
-version: "1.0"
+version: "1.0-1"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "null-45-data-view-extensions"
   include:

--- a/src/yaml/null-45/extended-terrain.yaml
+++ b/src/yaml/null-45/extended-terrain.yaml
@@ -1,7 +1,9 @@
 group: "null-45"
 name: "extended-terrain-dll"
-version: "1.0"
+version: "1.0-1"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "null-45-extended-terrain"
   include:

--- a/src/yaml/null-45/legalize-gambling-ordinance-upgrade.yaml
+++ b/src/yaml/null-45/legalize-gambling-ordinance-upgrade.yaml
@@ -1,7 +1,9 @@
 group: "null-45"
 name: "legalize-gambling-ordinance-upgrade-dll"
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "null-45-legalize-gambling-ordinance-upgrade"
   withChecksum:

--- a/src/yaml/null-45/lua-extensions.yaml
+++ b/src/yaml/null-45/lua-extensions.yaml
@@ -1,7 +1,9 @@
 group: "null-45"
 name: "lua-extensions-dll"
-version: "1.0.1"
+version: "1.0.1-1"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "null-45-lua-extensions"
   withChecksum:

--- a/src/yaml/null-45/more-demand-info.yaml
+++ b/src/yaml/null-45/more-demand-info.yaml
@@ -1,7 +1,9 @@
 group: "null-45"
 name: "more-demand-info-dll"
-version: "1.3"
+version: "1.3-1"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "null-45-more-demand-info"
   withChecksum:

--- a/src/yaml/null-45/query-tool-ui-extensions.yaml
+++ b/src/yaml/null-45/query-tool-ui-extensions.yaml
@@ -1,7 +1,9 @@
 group: "null-45"
 name: "query-tool-ui-extensions-dll"
-version: "2.5.0"
+version: "2.5.0-1"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "null-45-query-tool-ui-extensions"
   withChecksum:

--- a/src/yaml/null-45/regional-supply-demand.yaml
+++ b/src/yaml/null-45/regional-supply-demand.yaml
@@ -1,7 +1,9 @@
 group: "null-45"
 name: "regional-supply-demand-dll"
-version: "1.0"
+version: "1.0-1"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "null-45-regional-supply-demand"
   include:

--- a/src/yaml/null-45/sc4-resource-loading-hooks.yaml
+++ b/src/yaml/null-45/sc4-resource-loading-hooks.yaml
@@ -1,7 +1,9 @@
 group: "null-45"
 name: "sc4-resource-loading-hooks"
-version: "1.0.1"
+version: "1.0.1-1"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition-windows-digital"
 assets:
 - assetId: "null-45-sc4-resource-loading-hooks"
   withChecksum:

--- a/src/yaml/null-45/startup-performance-optimization-dll.yaml
+++ b/src/yaml/null-45/startup-performance-optimization-dll.yaml
@@ -1,7 +1,9 @@
 group: null-45
 name: startup-performance-optimization-dll
-version: "2.1"
+version: "2.1-1"
 subfolder: 150-mods
+dependencies:
+- config:sc4-edition-windows-digital
 assets:
 - assetId: null-45-sc4-dbpf-loading-dll
   withChecksum:

--- a/src/yaml/simmaster07/extra-cheats-dll.yaml
+++ b/src/yaml/simmaster07/extra-cheats-dll.yaml
@@ -1,7 +1,11 @@
 group: "simmaster07"
 name: "extra-cheats-dll"
-version: "1.1.1-2"
+version: "1.1.1-3"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition"
+conflicting:
+- "config:sc4-edition-macos"
 assets:
 - assetId: "simmaster07-extra-cheats-dll"
   withChecksum:

--- a/src/yaml/simmaster07/sc4fix.yaml
+++ b/src/yaml/simmaster07/sc4fix.yaml
@@ -1,7 +1,11 @@
 group: "simmaster07"
 name: "sc4fix"
-version: "1.0.7-1"
+version: "1.0.7-2"
 subfolder: "150-mods"
+dependencies:
+- "config:sc4-edition"
+conflicting:
+- "config:sc4-edition-macos"
 assets:
 - assetId: "simmaster07-sc4fix"
   withChecksum:

--- a/src/yaml/simmaster07/upgradeable-city-halls.yaml
+++ b/src/yaml/simmaster07/upgradeable-city-halls.yaml
@@ -1,7 +1,11 @@
 group: simmaster07
 name: upgradeable-city-halls-dll
-version: "1.1.0"
+version: "1.1.0-1"
 subfolder: 150-mods
+dependencies:
+- "config:sc4-edition"
+conflicting:
+- "config:sc4-edition-macos"
 assets:
 - assetId: simmaster07-real-upgradeable-city-halls
   withChecksum:


### PR DESCRIPTION
See #110.

This allows DLL mods to encode incompatibilities with the macOS version of the game.

For DLLs that require the Windows digital edition, add:
```yaml
dependencies:
- config:sc4-edition-windows-digital
```

For DLLs that are compatible with the disc edition as well, add:
```yaml
dependencies:
- config:sc4-edition
conflicting:
- config:sc4-edition-macos
```

Both cases trigger a dialog to select the version of the game (`Windows-digital`/`Windows-disc`/`macOS`).

If a package needs to install different files for macOS than for Windows, you can use:
```yaml
dependencies:
- config:sc4-edition
variants:
- &windows
  variant: { config:sc4-edition:edition: "Windows-digital" }
  assets: []  # …assets for Windows
- <<: *windows  # uses same Windows assets
  variant: { config:sc4-edition:edition: "Windows-disc" }
- variant: { config:sc4-edition:edition: "macOS" }
  assets: []  # …assets for macOS
```

By re-using the variant `config:sc4-edition:edition`, players need to select their game version only once.

CC: @UlisseWolf @noah-severyn @sebamarynissen @Zasco