### PR TITLE
Add CARCH Dependency

### DIFF
--- a/src/yaml/bsc/cerulean-dependencies.yaml
+++ b/src/yaml/bsc/cerulean-dependencies.yaml
@@ -1,0 +1,144 @@
+assetId: "sc4d-lex-legacy-cerulean-rci-and-cam-compilation-props"
+version: "1.0.0"
+lastModified: "2025-09-17T06:34:38-07:00"
+url: "https://www.sc4evermore.com/index.php/downloads?task=download.send&id=421:sc4d-lex-legacy-cerulean-rci-and-cam-compilation"
+
+---
+group: "bsc"
+name: "mega-props-bsc-carch-vol02"
+version: "1.0.0"
+subfolder: "100-props-textures"
+assets:
+- assetId: "sc4d-lex-legacy-cerulean-rci-and-cam-compilation-props"
+  include:
+  - "/BSC MEGA Props - CARCH Vol02.dat"
+info:
+  summary: "BSC MEGA Props CARCH Vol02"
+  description:
+    BSC MEGA Props CARCH Vol02 made by Cerulean
+  author: "Cerulean (CARCH)"
+  website: "https://www.sc4evermore.com/index.php/downloads/download/21-other/421-sc4d-lex-legacy-cerulean-rci-and-cam-compilation"
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCHLots.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/PreviewImage_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCH_Preview_Daggerstra_Entertainment_Hostel_Day.jpg
+
+---
+group: "bsc"
+name: "mega-props-bsc-carch-vol03"
+version: "1.0.0"
+subfolder: "100-props-textures"
+assets:
+- assetId: "sc4d-lex-legacy-cerulean-rci-and-cam-compilation-props"
+  include:
+  - "/BSC MEGA Props - CARCH Vol03.dat"
+info:
+  summary: "BSC MEGA Props CARCH Vol03"
+  description:
+    BSC MEGA Props CARCH Vol03 made by Cerulean
+  author: "Cerulean (CARCH)"
+  website: "https://www.sc4evermore.com/index.php/downloads/download/21-other/421-sc4d-lex-legacy-cerulean-rci-and-cam-compilation"
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCHLots.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/PreviewImage_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCH_Preview_Daggerstra_Entertainment_Hostel_Day.jpg
+
+---
+group: "bsc"
+name: "mega-props-bsc-carch-vol04"
+version: "1.0.0"
+subfolder: "100-props-textures"
+assets:
+- assetId: "sc4d-lex-legacy-cerulean-rci-and-cam-compilation-props"
+  include:
+  - "/BSC MEGA Props - CARCH Vol04.dat"
+info:
+  summary: "BSC MEGA Props CARCH Vol04"
+  description:
+    BSC MEGA Props CARCH Vol04 made by Cerulean
+  author: "Cerulean (CARCH)"
+  website: "https://www.sc4evermore.com/index.php/downloads/download/21-other/421-sc4d-lex-legacy-cerulean-rci-and-cam-compilation"
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCHLots.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/PreviewImage_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCH_Preview_Daggerstra_Entertainment_Hostel_Day.jpg
+
+---
+group: "bsc"
+name: "mega-props-bsc-carch-vol05"
+version: "1.0.0"
+subfolder: "100-props-textures"
+assets:
+- assetId: "sc4d-lex-legacy-cerulean-rci-and-cam-compilation-props"
+  include:
+  - "/BSC MEGA Props - CARCH Vol05.dat"
+info:
+  summary: "BSC MEGA Props CARCH Vol05"
+  description:
+    BSC MEGA Props CARCH Vol05 made by Cerulean
+  author: "Cerulean (CARCH)"
+  website: "https://www.sc4evermore.com/index.php/downloads/download/21-other/421-sc4d-lex-legacy-cerulean-rci-and-cam-compilation"
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCHLots.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/PreviewImage_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCH_Preview_Daggerstra_Entertainment_Hostel_Day.jpg
+
+---
+group: "bsc"
+name: "mega-props-bsc-carch-vol06"
+version: "1.0.0"
+subfolder: "100-props-textures"
+assets:
+- assetId: "sc4d-lex-legacy-cerulean-rci-and-cam-compilation-props"
+  include:
+  - "/BSC MEGA Props - CARCH Vol06.dat"
+info:
+  summary: "BSC MEGA Props CARCH Vol06"
+  description:
+    BSC MEGA Props CARCH Vol06 made by Cerulean
+  author: "Cerulean (CARCH)"
+  website: "https://www.sc4evermore.com/index.php/downloads/download/21-other/421-sc4d-lex-legacy-cerulean-rci-and-cam-compilation"
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCHLots.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/PreviewImage_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCH_Preview_Daggerstra_Entertainment_Hostel_Day.jpg
+
+---
+group: "bsc"
+name: "mega-props-bsc-carch-vol07"
+version: "1.0.0"
+subfolder: "100-props-textures"
+assets:
+- assetId: "sc4d-lex-legacy-cerulean-rci-and-cam-compilation-props"
+  include:
+  - "/BSC MEGA Props - CARCH Vol07.dat"
+info:
+  summary: "BSC MEGA Props CARCH Vol07"
+  description:
+    BSC MEGA Props CARCH Vol07 made by Cerulean
+  author: "Cerulean (CARCH)"
+  website: "https://www.sc4evermore.com/index.php/downloads/download/21-other/421-sc4d-lex-legacy-cerulean-rci-and-cam-compilation"
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCHLots.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/PreviewImage_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCH_Preview_Daggerstra_Entertainment_Hostel_Day.jpg
+
+---
+group: "bsc"
+name: "mega-props-bsc-carch-vol08"
+version: "1.0.0"
+subfolder: "100-props-textures"
+assets:
+- assetId: "sc4d-lex-legacy-cerulean-rci-and-cam-compilation-props"
+  include:
+  - "/BSC MEGA Props - CARCH Vol08.dat"
+info:
+  summary: "BSC MEGA Props CARCH Vol08"
+  description:
+    BSC MEGA Props CARCH Vol08 made by Cerulean
+  author: "Cerulean (CARCH)"
+  website: "https://www.sc4evermore.com/index.php/downloads/download/21-other/421-sc4d-lex-legacy-cerulean-rci-and-cam-compilation"
+  images:
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCHLots.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/PreviewImage_01.jpg
+    - https://www.sc4evermore.com/images/jdownloads/screenshots/CARCH_Preview_Daggerstra_Entertainment_Hostel_Day.jpg


### PR DESCRIPTION
This PR serves to reflect the move of BSC Mega Props CARCH Vol 2 -8 to the new download. 
This move will be necessary since version V9 and these dependencies will no longer be present in BSC Common Dependencies.