### PR TITLE
Move Peg Dependency

### DIFF
--- a/src/yaml/peg/christmas-development-kit.yaml
+++ b/src/yaml/peg/christmas-development-kit.yaml
@@ -9,25 +9,22 @@ info:
 
     This kit includes:
 
-    1\. Pine Tree/Christmas Tree. A common pine tree throughout the year... but decorated during the Holidays.
+    1. Pine Tree/Christmas Tree. A common pine tree throughout the year... but decorated during the Holidays.
 
-    2\. Billboard/Nativity Scene.  Typical ad hype for 11 months. Redressed with a beautiful nativity scene for Christmas.
+    2. Billboard/Nativity Scene.  Typical ad hype for 11 months. Redressed with a beautiful nativity scene for Christmas.
 
-    3\. Colored Christmas Lights. A short string of multicolored Christmas lights that can be strung together to decorate your favorite buildings. They only appear during the Holiday season.
+    3. Colored Christmas Lights. A short string of multicolored Christmas lights that can be strung together to decorate your favorite buildings. They only appear during the Holiday season.
 
-    4\. Small Nativity Scene. A common painted plywood decoration. Ideal for use on churches, parks or residential front yards. Appears only during the Holidays.
+    4. Small Nativity Scene. A common painted plywood decoration. Ideal for use on churches, parks or residential front yards. Appears only during the Holidays.
 
-    5\. Snowmen. Offered in large and Mucho Grande sizes. Appears only during the Holidays.
+    5. Snowmen. Offered in large and Mucho Grande sizes. Appears only during the Holidays.
 
-    6\. Santa Clauses. Two sizes and styles to choose from. Appears only during the Holidays.
+    6. Santa Clauses. Two sizes and styles to choose from. Appears only during the Holidays.
 
-    7 Santa's Sleigh. A large and colorful decoration suitable for display in plazas and shopping centers. Appears only during the Holidays.
+    7. Santa's Sleigh. A large and colorful decoration suitable for display in plazas and shopping centers. Appears only during the Holidays.
 
-    8\. Santa's Sleigh & Reindeer. The classic Holiday decoration that can be used almost anywhere. Appears only during the Holidays.
+    8. Santa's Sleigh & Reindeer. The classic Holiday decoration that can be used almost anywhere. Appears only during the Holidays.
 
-    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/).**
-
-    ***To all of you from all the members and staff at Pegasus Productions... Have a very, merry Holiday and a wonderful  New Year!***
   author: Pegasus
   website: https://community.simtropolis.com/files/file/11097-peg-christmas-development-kit/
   images:
@@ -37,6 +34,6 @@ assets:
 
 ---
 assetId: peg-christmas-development-kit
-version: "1.1-1"
+version: "1.1"
 lastModified: "2025-01-19T18:28:02Z"
 url: https://community.simtropolis.com/files/file/11097-peg-christmas-development-kit/?do=download&r=205376

--- a/src/yaml/peg/christmas-development-kit.yaml
+++ b/src/yaml/peg/christmas-development-kit.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: christmas-development-kit
-version: "1.1"
+version: "1.1-1"
 subfolder: 100-props-textures
 info:
   summary: Christmas Development Kit
@@ -37,6 +37,6 @@ assets:
 
 ---
 assetId: peg-christmas-development-kit
-version: "1.1"
+version: "1.1-1"
 lastModified: "2025-01-19T18:28:02Z"
 url: https://community.simtropolis.com/files/file/11097-peg-christmas-development-kit/?do=download&r=205376

--- a/src/yaml/peg/christmas-development-kit.yaml
+++ b/src/yaml/peg/christmas-development-kit.yaml
@@ -1,0 +1,42 @@
+group: peg
+name: christmas-development-kit
+version: "1.1"
+subfolder: 100-props-textures
+info:
+  summary: Christmas Development Kit
+  description: |-
+    Just in time for the Holidays... The PEG Christmas Development Pack contains 10 new seasonal props for developers to use on their lots. Two of the lots, those pictured in the upper images, are year-round props that change during the Holiday season. The other props appear only during the Holidays.
+
+    This kit includes:
+
+    1\. Pine Tree/Christmas Tree. A common pine tree throughout the year... but decorated during the Holidays.
+
+    2\. Billboard/Nativity Scene.  Typical ad hype for 11 months. Redressed with a beautiful nativity scene for Christmas.
+
+    3\. Colored Christmas Lights. A short string of multicolored Christmas lights that can be strung together to decorate your favorite buildings. They only appear during the Holiday season.
+
+    4\. Small Nativity Scene. A common painted plywood decoration. Ideal for use on churches, parks or residential front yards. Appears only during the Holidays.
+
+    5\. Snowmen. Offered in large and Mucho Grande sizes. Appears only during the Holidays.
+
+    6\. Santa Clauses. Two sizes and styles to choose from. Appears only during the Holidays.
+
+    7 Santa's Sleigh. A large and colorful decoration suitable for display in plazas and shopping centers. Appears only during the Holidays.
+
+    8\. Santa's Sleigh & Reindeer. The classic Holiday decoration that can be used almost anywhere. Appears only during the Holidays.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/).**
+
+    ***To all of you from all the members and staff at Pegasus Productions... Have a very, merry Holiday and a wonderful  New Year!***
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11097-peg-christmas-development-kit/
+  images:
+    - https://www.simtropolis.com/objects/screens/0014/77235ee54b5b3379d757e58ae1a3c902-product_image.jpg
+assets:
+  - assetId: peg-christmas-development-kit
+
+---
+assetId: peg-christmas-development-kit
+version: "1.1"
+lastModified: "2025-01-19T18:28:02Z"
+url: https://community.simtropolis.com/files/file/11097-peg-christmas-development-kit/?do=download&r=205376

--- a/src/yaml/peg/the-great-lighthouse-of-alexandria-props.yaml
+++ b/src/yaml/peg/the-great-lighthouse-of-alexandria-props.yaml
@@ -1,12 +1,12 @@
 assetId: "the-great-lighthouse-of-alexandria-props"
-version: "3.0.0"
+version: "2.0.0-1"
 lastModified: "2025-05-11T17:48:33Z"
 url: "https://community.simtropolis.com/files/file/13096-peg-the-great-lighthouse-of-alexandria/?do=download"
 
 ---
 group: "peg"
 name: "the-great-lighthouse-of-alexandria-props"
-version: "3.0.0"
+version: "2.0.0-1"
 subfolder: "100-props-textures"
 assets:
 - assetId: "the-great-lighthouse-of-alexandria-props"

--- a/src/yaml/peg/the-great-lighthouse-of-alexandria-props.yaml
+++ b/src/yaml/peg/the-great-lighthouse-of-alexandria-props.yaml
@@ -1,15 +1,15 @@
-assetId: "the-great-lighthouse-of-alexandria-props"
-version: "2.0.0-1"
+assetId: peg-the-great-lighthouse-of-alexandria
+version: "2.0"
 lastModified: "2025-05-11T17:48:33Z"
-url: "https://community.simtropolis.com/files/file/13096-peg-the-great-lighthouse-of-alexandria/?do=download"
+url: https://community.simtropolis.com/files/file/13096-peg-the-great-lighthouse-of-alexandria/?do=download&r=207619
 
 ---
 group: "peg"
 name: "the-great-lighthouse-of-alexandria-props"
-version: "2.0.0-1"
+version: "2.0-1"
 subfolder: "100-props-textures"
 assets:
-- assetId: "the-great-lighthouse-of-alexandria-props"
+- assetId: "peg-the-great-lighthouse-of-alexandria"
   include:
   - "/PEG_ Offset-Peeps_PROP.dat"
   - "/The Great Lighthouse-RESOURCE.dat"

--- a/src/yaml/peg/the-great-lighthouse-of-alexandria-props.yaml
+++ b/src/yaml/peg/the-great-lighthouse-of-alexandria-props.yaml
@@ -1,0 +1,24 @@
+assetId: "the-great-lighthouse-of-alexandria-props"
+version: "3.0.0"
+lastModified: "2025-05-11T17:48:33Z"
+url: "https://community.simtropolis.com/files/file/13096-peg-the-great-lighthouse-of-alexandria/?do=download"
+
+---
+group: "peg"
+name: "the-great-lighthouse-of-alexandria-props"
+version: "3.0.0"
+subfolder: "100-props-textures"
+assets:
+- assetId: "the-great-lighthouse-of-alexandria-props"
+  include:
+  - "/PEG_ Offset-Peeps_PROP.dat"
+  - "/The Great Lighthouse-RESOURCE.dat"
+info:
+  summary: "The Great Lighthouse of Alexandria props"
+  description:
+    Prop Pack for PEG The Great Lighthouse of Alexandria
+  author: "Pegasus"
+  website: "https://community.simtropolis.com/files/file/13096-peg-the-great-lighthouse-of-alexandria/"
+  images:
+    - https://www.simtropolis.com/objects/screens/0011/5cc975b429a681154f8d92b07570b03a-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0011/5cc975b429a681154f8d92b07570b03a-product_image2a.jpg


### PR DESCRIPTION
This PR is needed to move some Peg dependencies to the main channel, as they are dependencies used on both STEX and SC4E.