### PR TITLE
Add METMW: Prop Pack Alpha

### DIFF
--- a/src/yaml/huston/metmw-prop-pack-alpha.yaml
+++ b/src/yaml/huston/metmw-prop-pack-alpha.yaml
@@ -1,5 +1,5 @@
 group: huston
-name: huston-metmw-prop-pack-alpha
+name: metmw-prop-pack-alpha
 version: "2.0"
 subfolder: 100-props-textures
 info:

--- a/src/yaml/huston/metmw-prop-pack-alpha.yaml
+++ b/src/yaml/huston/metmw-prop-pack-alpha.yaml
@@ -3,7 +3,7 @@ name: huston-metmw-prop-pack-alpha
 version: "2.0"
 subfolder: 100-props-textures
 info:
-  summary: METMW: Prop Pack Alpha
+  summary: METMW Prop Pack Alpha
   description: |-
     Mass Effect Prop Pack by Huston
   author: Huston

--- a/src/yaml/huston/metmw-prop-pack-alpha.yaml
+++ b/src/yaml/huston/metmw-prop-pack-alpha.yaml
@@ -1,0 +1,20 @@
+group: huston
+name: huston-metmw-prop-pack-alpha
+version: "2.0"
+subfolder: 100-props-textures
+info:
+  summary: METMW: Prop Pack Alpha
+  description: |-
+    Mass Effect Prop Pack by Huston
+  author: Huston
+  website: https://community.simtropolis.com/files/file/29141-metmw-prop-pack-alpha/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_05_2015/23c98dfafcacef32a1c36aafbe6df2ee-humetmwproppackalphacoverpicture.jpg
+assets:
+  - assetId: huston-metmw-prop-pack-alpha
+
+---
+assetId: huston-metmw-prop-pack-alpha
+version: "2.0"
+lastModified: "2025-09-22T22:43:39Z"
+url: https://community.simtropolis.com/files/file/29141-metmw-prop-pack-alpha/?do=download


### PR DESCRIPTION
This PR is to enable METMW: Prop Pack Alpha to be added to the main channel.