### PR TITLE
update `barroco-hispano/agc-dlc`

### DIFF
--- a/src/yaml/barroco-hispano/agc-dlc.yaml
+++ b/src/yaml/barroco-hispano/agc-dlc.yaml
@@ -127,7 +127,7 @@ lastModified: "2023-12-19T00:46:38Z"
 ### agc street props
 group: "agc"
 name: "street-props"
-version: "6.0.0"
+version: "7"
 subfolder: "100-props-textures"
 info:
   summary: "Small props for streets and sidewalks"
@@ -152,8 +152,8 @@ variants:
 ---
 url: "https://community.simtropolis.com/files/file/36152-agc-streets-dlc/?do=download"
 assetId: "agc-street-props-dn"
-version: "6.0.0"
-lastModified: "2025-11-29T15:37:13Z"
+version: "7"
+lastModified: "2026-02-06T00:03:23Z"
 
 
 # ---


### PR DESCRIPTION
Update for `src/yaml/barroco-hispano/agc-dlc.yaml`:
```
Loaded report from /home/runner/work/_temp/api_reports/sc4e-report.json
All 0 SC4E assets are up-to-date (skipped 7 assets).
Loaded report from /home/runner/work/_temp/api_reports/stex-report.json
agc-street-props-dn:
  version: 6.0.0 -> 7.0.0
  lastModified: 2025-11-29T15:37:13Z -> 2026-02-06T00:03:23Z
  Website: https://community.simtropolis.com/files/file/36152-agc-streets-dlc/
  YAML: src/yaml/barroco-hispano/agc-dlc.yaml
There are 1 outdated STEX assets, while 0 are up-to-date (skipped 6 assets).
Updating src/yaml/barroco-hispano/agc-dlc.yaml ...
```
Website: https://community.simtropolis.com/files/file/36152-agc-streets-dlc/