### PR TITLE
update `andisart/sc2013-inspired-homes`

### DIFF
--- a/src/yaml/andisart/sc2013-inspired-homes.yaml
+++ b/src/yaml/andisart/sc2013-inspired-homes.yaml
@@ -1,6 +1,6 @@
 group: "andisart"
 name: "sc2013-inspired-homes"
-version: "1.0"
+version: "1.0-1"
 subfolder: "200-residential"
 info:
   summary: "Low-density residential homes inspired by SC2013"
@@ -23,12 +23,12 @@ variants:
 
 ---
 assetId: "andisart-sc13-style-homes-darknite"
-version: "1.0"
-lastModified: "2018-01-30T06:13:29Z"
-url: "https://community.simtropolis.com/files/file/29329-sc2013-inspired-homes-pack/?do=download&r=169867"
+version: "1.0-1"
+lastModified: "2026-03-20T18:37:46Z"
+url: "https://community.simtropolis.com/files/file/29329-sc2013-inspired-homes-pack/?do=download&r=212081"
 
 ---
 assetId: "andisart-sc13-style-homes-maxisnite"
-version: "1.0"
-lastModified: "2018-01-30T06:13:29Z"
-url: "https://community.simtropolis.com/files/file/29329-sc2013-inspired-homes-pack/?do=download&r=169868"
+version: "1.0-1"
+lastModified: "2026-03-20T18:37:46Z"
+url: "https://community.simtropolis.com/files/file/29329-sc2013-inspired-homes-pack/?do=download&r=212082"


### PR DESCRIPTION
Update for `src/yaml/andisart/sc2013-inspired-homes.yaml`:
```
Loaded report from /home/runner/work/_temp/api_reports/sc4e-report.json
All 0 SC4E assets are up-to-date (skipped 2 assets).
Loaded report from /home/runner/work/_temp/api_reports/stex-report.json
andisart-sc13-style-homes-darknite:
  version: 1.0 -> 1.0
  lastModified: 2018-01-30T06:13:29Z -> 2026-03-20T18:37:46Z
  Website: https://community.simtropolis.com/files/file/29329-sc2013-inspired-homes-pack/
  YAML: src/yaml/andisart/sc2013-inspired-homes.yaml
  Subfiles:
    212081: AndisArt - SC13-style_homes DARKNITE.zip
    212082: AndisArt - SC13-style_homes MAXISNITE.zip
  Note: subfile ID 169867 not found among subfiles, so URL must be updated
andisart-sc13-style-homes-maxisnite:
  version: 1.0 -> 1.0
  lastModified: 2018-01-30T06:13:29Z -> 2026-03-20T18:37:46Z
  Website: https://community.simtropolis.com/files/file/29329-sc2013-inspired-homes-pack/
  YAML: src/yaml/andisart/sc2013-inspired-homes.yaml
  Subfiles:
    212081: AndisArt - SC13-style_homes DARKNITE.zip
    212082: AndisArt - SC13-style_homes MAXISNITE.zip
  Note: subfile ID 169868 not found among subfiles, so URL must be updated
There are 2 outdated STEX assets, while 0 are up-to-date.
Updating src/yaml/andisart/sc2013-inspired-homes.yaml ...
```
Website: https://community.simtropolis.com/files/file/29329-sc2013-inspired-homes-pack/