### PR TITLE
update `null-45/query-tool-ui-extensions`

### DIFF
--- a/src/yaml/null-45/query-tool-ui-extensions.yaml
+++ b/src/yaml/null-45/query-tool-ui-extensions.yaml
@@ -1,6 +1,6 @@
 group: "null-45"
 name: "query-tool-ui-extensions-dll"
-version: "2.6.4"
+version: "2.6.5"
 subfolder: "150-mods"
 dependencies:
 - "config:sc4-edition-windows-digital"
@@ -8,7 +8,7 @@ assets:
 - assetId: "null-45-query-tool-ui-extensions"
   withChecksum:
   - include: "/SC4QueryUIHooks.dll"
-    sha256: acc120b90f118c8dc41a33684ab54a58c2d93b014b63f7c7454df7c488975358
+    sha256: 95c055f915ff8b286c74bc27e76fcd94ddf88d2c3f9430bb54d8a66da77e8625
   - include: "/SC4QueryUIHooks.ini"
     sha256: 25C2065EA205B46C3D1B487C5907E2F9EB44C1CAAD8AEC89CD43EA4DD0A834D3
 
@@ -58,7 +58,7 @@ info:
 
 ---
 assetId: "null-45-query-tool-ui-extensions"
-version: "2.6.4"
-lastModified: "2026-03-31T09:44:10Z"
+version: "2.6.5"
+lastModified: "2026-04-15T03:11:35Z"
 nonPersistentUrl: "https://community.simtropolis.com/files/file/36202-query-tool-ui-extensions-dll-for-simcity-4/?do=download"
-url: "https://github.com/0xC0000054/sc4-query-ui-hooks/releases/download/v2.6.4/SC4QueryUIHooks.zip"
+url: "https://github.com/0xC0000054/sc4-query-ui-hooks/releases/download/v2.6.5/SC4QueryUIHooks.zip"


### PR DESCRIPTION
Update for `src/yaml/null-45/query-tool-ui-extensions.yaml`:
```
Loaded report from /home/runner/work/_temp/api_reports/sc4e-report.json
All 0 SC4E assets are up-to-date (skipped 1 assets).
Loaded report from /home/runner/work/_temp/api_reports/stex-report.json
null-45-query-tool-ui-extensions:
  version: 2.6.4 -> 2.6.5
  lastModified: 2026-03-31T09:44:10Z -> 2026-04-15T03:11:35Z
  Website: https://community.simtropolis.com/files/file/36202-query-tool-ui-extensions-dll-for-simcity-4/
  YAML: src/yaml/null-45/query-tool-ui-extensions.yaml
There are 1 outdated STEX assets, while 0 are up-to-date.
Updating src/yaml/null-45/query-tool-ui-extensions.yaml ...
Downloading https://github.com/0xC0000054/sc4-query-ui-hooks/releases/download/v2.6.5/SC4QueryUIHooks.zip ...
Download finished.
```
Website: https://community.simtropolis.com/files/file/36202-query-tool-ui-extensions-dll-for-simcity-4/