### PR TITLE
update `lbt/latin-american-housepack`

### DIFF
--- a/src/yaml/lbt/latin-american-housepack.yaml
+++ b/src/yaml/lbt/latin-american-housepack.yaml
@@ -1,6 +1,6 @@
 group: "lbt"
 name: "latin-american-housepack-props"
-version: "2.0"
+version: "2.0-1"
 subfolder: "100-props-textures"
 assets:
 - assetId: "lbt-prop-pack-latin-american-housepack"
@@ -12,6 +12,6 @@ info:
 
 ---
 assetId: "lbt-prop-pack-latin-american-housepack"
-version: "2.0"
-lastModified: "2023-11-21T15:18:56-08:00"
+version: "2.0-1"
+lastModified: "2026-05-16T10:39:55Z"
 url: "https://www.sc4evermore.com/index.php/downloads?task=download.send&id=178:lbt-prop-pack-latin-american-housepack"


### PR DESCRIPTION
Update for `src/yaml/lbt/latin-american-housepack.yaml`:
```
Loaded report from /home/runner/work/_temp/api_reports/sc4e-report.json
lbt-prop-pack-latin-american-housepack:
  version: 2.0 -> 2.0
  lastModified: 2023-11-21T15:18:56-08:00 -> 2026-05-16T10:39:55Z
  Website: https://www.sc4evermore.com/index.php/downloads/download/178
  YAML: src/yaml/lbt/latin-american-housepack.yaml
There are 1 outdated SC4E assets, while 0 are up-to-date.
Updating src/yaml/lbt/latin-american-housepack.yaml ...
```
Website: https://www.sc4evermore.com/index.php/downloads/download/178