### PR TITLE
update `cam/cam-ordinances`

### DIFF
--- a/src/yaml/cam/cam-ordinances.yaml
+++ b/src/yaml/cam/cam-ordinances.yaml
@@ -1,6 +1,6 @@
 group: "cam"
 name: "ordinances"
-version: "3.3.0-1"
+version: "3.3.0-2"
 subfolder: "140-ordinances"
 dependencies:
 - "null-45:custom-ordinance-exemplar-host-dll"
@@ -26,6 +26,6 @@ info:
 
 ---
 assetId: "cam-colossus-addon-mod-ordinances"
-version: "3.3.0"
-lastModified: "2025-09-04T10:19:10-07:00"
+version: "3.3.0-1"
+lastModified: "2026-06-07T13:17:06Z"
 url: "https://www.sc4evermore.com/index.php/downloads?task=download.send&id=386:colossus-addon-mod-ordinances"


### PR DESCRIPTION
Update for `src/yaml/cam/cam-ordinances.yaml`:
```
Loaded report from /home/runner/work/_temp/api_reports/sc4e-report.json
cam-colossus-addon-mod-ordinances:
  version: 3.3.0 -> 3.3.0
  lastModified: 2025-09-04T10:19:10-07:00 -> 2026-06-07T13:17:06Z
  Website: https://www.sc4evermore.com/index.php/downloads/download/386
  YAML: src/yaml/cam/cam-ordinances.yaml
There are 1 outdated SC4E assets, while 0 are up-to-date.
Updating src/yaml/cam/cam-ordinances.yaml ...
```
Website: https://www.sc4evermore.com/index.php/downloads/download/386