### PR TITLE
update `nos17/sc2013-homes-redone`

### DIFF
--- a/src/yaml/nos17/sc2013-homes-redone.yaml
+++ b/src/yaml/nos17/sc2013-homes-redone.yaml
@@ -1,7 +1,7 @@
 # Package
 group: "nos17"
 name: "andisart-sc2013-homes-redone"
-version: "1.2"
+version: "1.2-1"
 subfolder: "200-residential"
 dependencies:
   - "andisart:sc2013-inspired-homes"
@@ -36,6 +36,6 @@ info:
 ---
 # Asset
 assetId: "nos17-andisart-sc2013-homes-redone"
-version: "1.2"
-lastModified: "2024-08-23T00:36:02Z"
+version: "1.2-1"
+lastModified: "2026-06-16T17:17:35Z"
 url: "https://community.simtropolis.com/files/file/33379-andisart-sc13-homes-redone/?do=download"


### PR DESCRIPTION
Update for `src/yaml/nos17/sc2013-homes-redone.yaml`:
```
Loaded report from /home/runner/work/_temp/api_reports/sc4e-report.json
All 0 SC4E assets are up-to-date (skipped 1 assets).
Loaded report from /home/runner/work/_temp/api_reports/stex-report.json
nos17-andisart-sc2013-homes-redone:
  version: 1.2 -> 1.2
  lastModified: 2024-08-23T00:36:02Z -> 2026-06-16T17:17:35Z
  Website: https://community.simtropolis.com/files/file/33379-andisart-sc13-homes-redone/
  YAML: src/yaml/nos17/sc2013-homes-redone.yaml
There are 1 outdated STEX assets, while 0 are up-to-date.
Updating src/yaml/nos17/sc2013-homes-redone.yaml ...
```
Website: https://community.simtropolis.com/files/file/33379-andisart-sc13-homes-redone/